### PR TITLE
Fix Bandcamp regexes not matching links ending with `/`

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
@@ -33,8 +33,8 @@ import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.
  * Audio source manager that implements finding Bandcamp tracks based on URL.
  */
 public class BandcampAudioSourceManager implements AudioSourceManager {
-  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com/track/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
-  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com/album/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
+  private static final String TRACK_URL_REGEX = "^https?://(?:[^.]+\\.|)bandcamp\\.com/track/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
+  private static final String ALBUM_URL_REGEX = "^https?://(?:[^.]+\\.|)bandcamp\\.com/album/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
 
   private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
   private static final Pattern albumUrlPattern = Pattern.compile(ALBUM_URL_REGEX);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
@@ -33,8 +33,8 @@ import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.
  * Audio source manager that implements finding Bandcamp tracks based on URL.
  */
 public class BandcampAudioSourceManager implements AudioSourceManager {
-  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/track\\/([a-zA-Z0-9-_]+)\\/?(?:\\?.*|)$";
-  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/album\\/([a-zA-Z0-9-_]+)\\/?(?:\\?.*|)$";
+  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com/track/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
+  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com/album/([a-zA-Z0-9-_]+)/?(?:\\?.*|)$";
 
   private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
   private static final Pattern albumUrlPattern = Pattern.compile(ALBUM_URL_REGEX);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
@@ -33,8 +33,8 @@ import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.
  * Audio source manager that implements finding Bandcamp tracks based on URL.
  */
 public class BandcampAudioSourceManager implements AudioSourceManager {
-  private static final String TRACK_URL_REGEX = "^(?:http://|https://)(?:[^.]+\\.|)bandcamp\\.com/track/([a-zA-Z0-9-_]+)(?:\\?.*|)$";
-  private static final String ALBUM_URL_REGEX = "^(?:http://|https://)(?:[^.]+\\.|)bandcamp\\.com/album/([a-zA-Z0-9-_]+)(?:\\?.*|)$";
+  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/track\\/([a-zA-Z0-9-_]+)(?:\\?.*|)\\/?$";
+  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/album\\/([a-zA-Z0-9-_]+)(?:\\?.*|)\\/?$";
 
   private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
   private static final Pattern albumUrlPattern = Pattern.compile(ALBUM_URL_REGEX);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
@@ -33,8 +33,8 @@ import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.
  * Audio source manager that implements finding Bandcamp tracks based on URL.
  */
 public class BandcampAudioSourceManager implements AudioSourceManager {
-  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/track\\/([a-zA-Z0-9-_]+)(?:\\?.*|)\\/?$";
-  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/album\\/([a-zA-Z0-9-_]+)(?:\\?.*|)\\/?$";
+  private static final String TRACK_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/track\\/([a-zA-Z0-9-_]+)\\/?(?:\\?.*|)$";
+  private static final String ALBUM_URL_REGEX = "^https?:\\/\\/(?:[^.]+\\.|)bandcamp\\.com\\/album\\/([a-zA-Z0-9-_]+)\\/?(?:\\?.*|)$";
 
   private static final Pattern trackUrlPattern = Pattern.compile(TRACK_URL_REGEX);
   private static final Pattern albumUrlPattern = Pattern.compile(ALBUM_URL_REGEX);


### PR DESCRIPTION
Fixed Bandcamp regexes so that
https://cysmix.bandcamp.com/album/escapism/
is just as valid as
https://cysmix.bandcamp.com/album/escapism

Regexes have only been tested on http://www.regexpal.com/, not at actual runtime
