### PR TITLE
Fixed a method call in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ public class TrackScheduler extends AudioEventAdapter {
 
   @Override
   public void onTrackEnd(AudioPlayer player, AudioTrack track, AudioTrackEndReason endReason) {
-    if (track.mayStartNext) {
+    if (endReason.mayStartNext) {
       // Start next track
     }
 


### PR DESCRIPTION
 AudioTrack doesn't have mayStartNext, AudioTrackEndReason does.