### PR TITLE
Add ARM support [wrong branch]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,13 +20,17 @@ group = 'com.sedmelluq'
 import org.apache.tools.ant.taskdefs.condition.Os
 
 def getBuildParameters(base, bits) {
-  def bitSuffix = (bits == 32) ? 'x86' : 'x86-64'
+  def bitSuffix = bits
+
+  if (bits == '32' || bits == '64') {
+    bitSuffix = (bits == '32') ? 'x86' : 'x86-64'
+  }
 
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     return [
         'identifier': "win-${bitSuffix}",
         'library': "${base}.dll",
-        'setupArguments': ["-DBITZ:STRING=${bits}", '-A', (bits == 64 ? 'x64' : 'Win32')],
+        'setupArguments': ["-DBITZ:STRING=${bits}", '-A', (bits == '64' ? 'x64' : 'Win32')],
         'buildArguments': ['--config', 'Release'],
         'env': [:]
     ]
@@ -36,7 +40,7 @@ def getBuildParameters(base, bits) {
         'library': "lib${base}.dylib",
         'setupArguments': ["-DBITZ:STRING=${bits}"],
         'buildArguments': [],
-        'env': ['CXXFLAGS': "-m${bits}", 'CFLAGS': "-m${bits}", 'LDFLAGS': "-m${bits}"]
+        'env': ['CFLAGS': "-m${bits}", 'CXXFLAGS': "-m${bits}"]
     ]
   } else {
     return [
@@ -44,7 +48,7 @@ def getBuildParameters(base, bits) {
         'library': "lib${base}.so",
         'setupArguments': ["-DBITZ:STRING=${bits}"],
         'buildArguments': [],
-        'env': ['CXXFLAGS': "-m${bits}", 'CFLAGS': "-m${bits}", 'LDFLAGS': "-m${bits}"]
+        'env': ['CFLAGS': "-m${bits}", 'CXXFLAGS': "-m${bits}"]
     ]
   }
 }
@@ -61,7 +65,7 @@ def createBuildTask(tasksHolder, config, bits) {
   def deployDirectory = "${config.deployBase}/src/main/resources/natives/${parameters.identifier}"
   def taskBase = "${config.name}-${bits}"
 
-  if (Os.isFamily(Os.FAMILY_MAC) && bits != 64) {
+  if (Os.isFamily(Os.FAMILY_MAC) && bits != '64') {
     return
   }
 

--- a/main/build.gradle
+++ b/main/build.gradle
@@ -3,10 +3,12 @@ plugins {
   id 'application'
   id 'org.sonarqube' version '2.1'
   id 'com.jfrog.bintray' version '1.7.3'
+  id "com.github.johnrengelman.shadow" version "1.2.4"
 }
-
+mainClassName = 'com.sedmelluq.discord.lavaplayer.NullClass'
 ext.moduleName = 'lavaplayer'
 version = '1.2.9'
+shadowJar.archiveName = 'lavaplayer-1.2.9.jar'
 
 dependencies {
   compile project(':common')

--- a/natives/build.gradle
+++ b/natives/build.gradle
@@ -164,8 +164,14 @@ def buildOpusOnLinux(bits, force) {
   def present = file("${projectDir}/libs/${bits}/libopus.a").exists()
 
   if (force || !present) {
+    def bitSuffix = bits
+
+    if (bits == '32' || bits == '64') {
+      bitSuffix = (bits == '32') ? 'x86' : 'x86-64'
+    }
+
     def flags = "-m${bits} -fPIC -O3"
-    def process = ["./configure", "--enable-static", "--with-cpu=" + (bits == 32 ? "x86" : "x64-64"), "--with-pic", "CFLAGS=${flags}", "CXXFLAGS=${flags}", "LDFLAGS=${flags}"].
+    def process = ["./configure", "--enable-static", "--with-cpu=" + bitSuffix, "--with-pic", "CFLAGS=${flags}", "CXXFLAGS=${flags}"].
         execute(null as String[], file("$projectDir/opus/opus-1.1.3"))
 
     waitForAndCheckSuccess(process, "Opus ./configure")
@@ -190,7 +196,18 @@ def buildMpg123OnLinux(bits, force) {
     def process = ["patch", "-N", "mpg123-1.23.8/configure", "configure.patch"].execute(null as String[], file("$projectDir/mp3"))
     process.waitForProcessOutput(System.out as Appendable, System.err)
 
-    process = ["./configure", "--enable-static", "--with-cpu=" + (bits == 32 ? "x86" : "x86-64"), "--with-pic", "CFLAGS=-fPIC -O3 -m${bits}", "CXXFLAGS=-fPIC -O3 -m${bits}"].
+    def bitSuffix = bits
+
+    if (bits == '32' || bits == '64') {
+      bitSuffix = (bits == '32') ? 'x86' : 'x86-64'
+    }
+
+    if (bits == 'arm') {
+      bitSuffix = 'arm_fpu'
+    }
+
+    def flags = "-m${bits} -fPIC -O3"
+    process = ["./configure", "--enable-static", "--with-cpu=" + bitSuffix, "--with-pic", "CFLAGS=${flags}", "CXXFLAGS=${flags}"].
         execute(null as String[], file("$projectDir/mp3/mpg123-1.23.8"))
 
     waitForAndCheckSuccess(process, "Mpg123 ./configure")
@@ -212,7 +229,14 @@ def prepareOggOnLinux(bits, force) {
   def configured = file("$projectDir/vorbis/libogg-1.3.2/include/ogg/config_types.h").exists()
 
   if (force || !configured) {
-    def process = ["./configure", "--enable-static", "--build=x86_64-pc-linux-gnu", "--with-pic"].
+    def bitSuffix = bits
+
+    if (bits == '32' || bits == '64') {
+      bitSuffix = (bits == '32') ? 'x86' : 'x86-64'
+    }
+
+    def flags = "-m${bits} -fPIC -O3"
+    def process = ["./configure", "--enable-static", "--with-cpu=" + bitSuffix, "--with-pic", "CFLAGS=${flags}", "CXXFLAGS=${flags}"].
         execute(null as String[], file("$projectDir/vorbis/libogg-1.3.2"))
 
     process.waitForProcessOutput(System.out as Appendable, System.err)
@@ -243,5 +267,6 @@ def buildTaskConfig = [
     name: 'connector'
 ]
 
-createBuildTask(tasks, buildTaskConfig, 32)
-createBuildTask(tasks, buildTaskConfig, 64)
+createBuildTask(tasks, buildTaskConfig, '32')
+createBuildTask(tasks, buildTaskConfig, '64')
+//createBuildTask(tasks, buildTaskConfig, 'arm')

--- a/natives/connector/vorbis.c
+++ b/natives/connector/vorbis.c
@@ -85,7 +85,8 @@ JNIEXPORT jint JNICALL Java_com_sedmelluq_discord_lavaplayer_natives_vorbis_Vorb
 	size_t chunk = available > buffer_length ? buffer_length : available;
 
 	if (chunk > 0) {
-		for (int i = 0; i < state->info.channels; i++) {
+		int i;
+		for (i = 0; i < state->info.channels; i++) {
 			jfloatArray channel = (*jni)->GetObjectArrayElement(jni, channels, i);
 
 			if (channel != NULL) {


### PR DESCRIPTION
Added the ability to compile on ARM environment. Tested on Raspberry Pi 3.

This fixed the native library crash that occurred because of incompatible architecture.

At the moment this is disabled as gcc-x86 can't cross-compile ARM binaries.
To compile for ARM go to "natives/build.gradle" and scroll to the bottom and change according:

//createBuildTask(tasks, buildTaskConfig, '32')
//createBuildTask(tasks, buildTaskConfig, '64')
createBuildTask(tasks, buildTaskConfig, 'arm')

Only works on an ARM environment, such as RPi 3