### PR TITLE
Add support for beam's new name: mixer.com

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamAudioSourceManager.java
@@ -28,7 +28,7 @@ import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.
  * Audio source manager which detects Beam.pro tracks by URL.
  */
 public class BeamAudioSourceManager implements AudioSourceManager, HttpConfigurable {
-  private static final String STREAM_NAME_REGEX = "^https://(?:www\\.)?beam.pro/([^/]+)$";
+  private static final String STREAM_NAME_REGEX = "^https://(?:www\\.)?(?:beam\\.pro|mixer\\.com)/([^/]+)$";
   private static final Pattern streamNameRegex = Pattern.compile(STREAM_NAME_REGEX);
 
   private final HttpInterfaceManager httpInterfaceManager;


### PR DESCRIPTION
https://blog.mixer.com/welcome/