### PR TITLE
Local audio source track encoding

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/local/LocalAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/local/LocalAudioSourceManager.java
@@ -1,9 +1,6 @@
 package com.sedmelluq.discord.lavaplayer.source.local;
 
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.*;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.ProbingAudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
@@ -54,17 +51,25 @@ public class LocalAudioSourceManager extends ProbingAudioSourceManager {
 
   @Override
   public boolean isTrackEncodable(AudioTrack track) {
-    return false;
+    return true;
   }
 
   @Override
-  public void encodeTrack(AudioTrack track, DataOutput output) {
-    throw new UnsupportedOperationException();
+  public void encodeTrack(AudioTrack track, DataOutput output) throws IOException {
+    output.writeUTF(((LocalAudioTrack) track).getProbe().getName());
   }
 
   @Override
-  public AudioTrack decodeTrack(AudioTrackInfo trackInfo, DataInput input) {
-    throw new UnsupportedOperationException();
+  public AudioTrack decodeTrack(AudioTrackInfo trackInfo, DataInput input) throws IOException {
+    String probeName = input.readUTF();
+
+    for (MediaContainer container : MediaContainer.class.getEnumConstants()) {
+      if (container.probe.getName().equals(probeName)) {
+        return new LocalAudioTrack(trackInfo, container.probe, this);
+      }
+    }
+
+    return null;
   }
 
   @Override

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/local/LocalAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/local/LocalAudioTrack.java
@@ -31,6 +31,13 @@ public class LocalAudioTrack extends DelegatedAudioTrack {
     this.sourceManager = sourceManager;
   }
 
+  /**
+   * @return The media probe which handles creating a container-specific delegated track for this track.
+   */
+  public MediaContainerProbe getProbe() {
+    return probe;
+  }
+
   @Override
   public void process(LocalAudioTrackExecutor localExecutor) throws Exception {
     try (LocalSeekableInputStream inputStream = new LocalSeekableInputStream(file)) {


### PR DESCRIPTION
Implemented the #encodeTrack and #decodeTrack methods for the LocalAudioSourceManager. I don't know why these weren't originally implemented so if there's a reason feel free to close :)