### PR TITLE
Fix fixup of protocol in bandcamp URLs

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioTrack.java
@@ -61,7 +61,7 @@ public class BandcampAudioTrack extends DelegatedAudioTrack {
       String responseText = IOUtils.toString(response.getEntity().getContent(), StandardCharsets.UTF_8);
       JsonBrowser trackInfo = sourceManager.readTrackListInformation(responseText);
 
-      return "https:" + trackInfo.get("trackinfo").index(0).get("file").get("mp3-128").text();
+      return trackInfo.get("trackinfo").index(0).get("file").get("mp3-128").text();
     }
   }
 


### PR DESCRIPTION
Lately we've found that no URLs load, since these URLs already contain the https:// protocol.