### PR TITLE
Improve loading of YouTube tracks

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -56,7 +56,9 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
   private static final String PLAYLIST_ID_REGEX = "(?<list>(PL|LL|FL|UU)[a-zA-Z0-9_-]+)";
   private static final String MIX_ID_REGEX = "(?<mix>RD[a-zA-Z0-9_-]+)";
   private static final String PLAYLIST_ID_OR_MIX_ID_REGEX = "(?:" + PLAYLIST_ID_REGEX + "|" + MIX_ID_REGEX + ")";
-  private static final String ANY_REGEX = "\\w+=\\w+";
+
+  // As mentioned in RFC 3986 (BNF unreserved) https://tools.ietf.org/html/rfc3986#page-50
+  private static final String ANY_REGEX = "[\\w~.-]+=[\\w~.-]+";
 
   private static final String PARAMETER_REGEX = "(?:v=" + VIDEO_ID_REGEX + "|list=" + PLAYLIST_ID_OR_MIX_ID_REGEX + "|" + ANY_REGEX + ")&?";
   private static final String PARAMETERS_REGEX = "(?:" + PARAMETER_REGEX + ")+";

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -233,13 +233,17 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       if (matcher.matches()) {
         String videoId = matcher.group("v");
 
-        if (matcher.group("list") != null) {
-          return loadLinkedPlaylistWithId(matcher.group("list"), videoId);
-        } else if (matcher.group("mix") != null) {
-          return mixProvider.loadMixWithId(matcher.group("mix"), videoId);
-        } else {
-          return loadTrackWithVideoId(videoId, false);
+        try {
+          if (matcher.group("list") != null) {
+            return loadLinkedPlaylistWithId(matcher.group("list"), videoId);
+          } else if (matcher.group("mix") != null) {
+            return mixProvider.loadMixWithId(matcher.group("mix"), videoId);
+          }
+        } catch (IllegalArgumentException groupNotPresent) {
+          // this is fine, although I'd rather have a querying alternative
         }
+
+        return loadTrackWithVideoId(videoId, false);
       }
     }
 


### PR DESCRIPTION
This would allow links with `&feature=youtu.be` to match, and I noticed that the regex handling relies on the `list` parameter to be always there.