### PR TITLE
Correctly resolve the twitch stream segments

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/beam/BeamSegmentUrlProvider.java
@@ -62,10 +62,6 @@ public class BeamSegmentUrlProvider extends M3uStreamSegmentUrlProvider {
     }
   }
 
-  private static String createSegmentUrl(String playlistUrl, String segmentName) {
-    return playlistUrl.substring(0, playlistUrl.lastIndexOf('/') + 1) + segmentName;
-  }
-
   private boolean obtainSegmentPlaylistUrl(HttpInterface httpInterface) throws IOException {
     if (streamSegmentPlaylistUrl != null) {
       return true;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/stream/M3uStreamSegmentUrlProvider.java
@@ -7,6 +7,7 @@ import org.apache.http.client.methods.HttpGet;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,6 +21,11 @@ import static com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools.fetchRes
  * {@link M3uStreamSegmentUrlProvider#getNextSegmentStream}.
  */
 public abstract class M3uStreamSegmentUrlProvider {
+
+  protected static String createSegmentUrl(String playlistUrl, String segmentName) {
+    return URI.create(playlistUrl).resolve(segmentName).toString();
+  }
+
   /**
    * If applicable, extracts the quality information from the M3U directive which describes one stream in the root M3U.
    *

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamSegmentUrlProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamSegmentUrlProvider.java
@@ -71,10 +71,6 @@ public class TwitchStreamSegmentUrlProvider extends M3uStreamSegmentUrlProvider 
     }
   }
 
-  private static String createSegmentUrl(String playlistUrl, String segmentName) {
-    return playlistUrl.substring(0, playlistUrl.lastIndexOf('/') + 1) + segmentName;
-  }
-
   private boolean obtainSegmentPlaylistUrl(HttpInterface httpInterface) throws IOException {
     if (System.currentTimeMillis() < tokenExpirationTime) {
       return true;


### PR DESCRIPTION
This solves the intermittent 403s.

Example change:
```
newUri = https://video-edge-c55f64.ams02.hls.ttvnw.net/v1/segment/CtcClbSUIeqGAkPEY52nwDCBslkcbCiH904ryM28uxlwFuAe1MlREy14si_Rl4-xf1KXFCTtVXZV-3kPcgdYVAq99mXjWq4zEZtP7Ozrj1g7ID1YZUhHk8xcmWgZKULJiV8Bq5pJfT86FivKChl-FI4h6nhEaGBPeEnJ8LfIqx-Lc2pJU3Yikm-lSCjR-WxeFqpC34-Tj3Fin5UE8D1FHZGkKycXIXc3hfVg-Fru0XWjG-oenFyA6ziDQcnWxZqeHA8fbNtn36i3yJH7RAb-EfD7LSmZrAQVCBxEyUqnnXhzpVQP2N1r46qu0ibxB6dHPnO0sOgs-zXZFwrtQaqFFQEyG0S4jhsD1Fkod0KAulpTCCLmSTeBDOtFPcBt_Flrgtk5Fe-LlyGUmvEHSLmBHdOYRXJouJ8tJM-tQ1hdMX1WNk_MZ8SglF_AQj_nC-Dc05TrpmVxNaxv4hIQF9kJ_u2NpFZyqiwBk7mvHRoMak8zlX76NR50E9i5.ts
oldUri = https://video-weaver.ams02.hls.ttvnw.net/v1/playlist/https://video-edge-c55f64.ams02.hls.ttvnw.net/v1/segment/CtcCokCG8bSpOD6T_7PdiMrFTTPkOGSQCOY-1IGCSVUMObJkUt6thiIANtijC73sQQ5IHm3GrdCUt1dUR6ubIZwTHB70yD8EeaD9F-7f_5HUDLXV2_FX58QTKBc3evonN5ZptgSEeLCfPV-1yWRUdnnP02pcLS_Rv9HW8iYdOBO5sJeWGOfQEI8U-uJXxuApK8l54GMPultrGRfr5yjyMg5ZTOVUmRfXPI2s648PED_O9vpnmGjUJekcn2k-pexU3gij5T-7771_EZdGzNsPAe5VwvJ03oCuVbomav2DDY1_-po8iMExf1VEQ2NKQiuiAONBicTVjwgsjkxW2Js5prps5gTgd30SCMjMLjgoHyxokJsGFChrf9Usc1DP4tmDYiKGU2E68dTTsZmOJHKcNkHQt2OGhu9-KadTunE8D_wzHZzGsY5hhD-AKKY-jmGKv9kksy48lG513RIQnLOIc32eBhZ34LfldEHgPRoMmIZbxvM9l-JukUi-.ts
```
(also status quo when the segmentName is just `index-0000042803-zg81.ts`)
```
oldUri = https://video-edge-c55f64.ams02.hls.ttvnw.net/v0/Cv0BYlN_aO6EUz-npodK4fYPCqjbaxMzi2PD-qpIgjrF5iT2ph6-CIrutif3w8CYTUUNroDPluUJsd8gTeNncC7ouJ1DdBBOC5UZuk8mJL1r87HjakgR4RlR3h1kZx0NiRXXGXJNb6mXbdEcAb2oejNe8Tau7chGOIsmw4qnxRcj1FE1Oa8GWTNKx8sH58aZJY_90247n8ClzeNRTBFiedzuGQnpNgbiFJbHSjn6IUgLHaV0abwIWaCgU0HyRQwbsDhmCtIJycD-AU60O7hJypf_okKEbwb1w-xElrOkRPfDikiT8-vMBHAJ5Yvj5fmzSggP5KKuLajv49bayJYvxRIQUORkcxvey5A6ZbXQ5ya6XhoMZGLjXkQ-JIJtTXMR/index-0000042803-zg81.ts
void
newUri = https://video-edge-c55f64.ams02.hls.ttvnw.net/v0/Cv0BYlN_aO6EUz-npodK4fYPCqjbaxMzi2PD-qpIgjrF5iT2ph6-CIrutif3w8CYTUUNroDPluUJsd8gTeNncC7ouJ1DdBBOC5UZuk8mJL1r87HjakgR4RlR3h1kZx0NiRXXGXJNb6mXbdEcAb2oejNe8Tau7chGOIsmw4qnxRcj1FE1Oa8GWTNKx8sH58aZJY_90247n8ClzeNRTBFiedzuGQnpNgbiFJbHSjn6IUgLHaV0abwIWaCgU0HyRQwbsDhmCtIJycD-AU60O7hJypf_okKEbwb1w-xElrOkRPfDikiT8-vMBHAJ5Yvj5fmzSggP5KKuLajv49bayJYvxRIQUORkcxvey5A6ZbXQ5ya6XhoMZGLjXkQ-JIJtTXMR/index-0000042803-zg81.ts
```
So the naive way of resolving by just appending doesn't always work.
In the case twitch decides to hand off to a different edge host, the link will not point to anything sensible (`:` is not valid in the base64 alphabet)