### PR TITLE
Add Missing Import statement

### DIFF
--- a/demo-d4j/src/main/java/com/sedmelluq/discord/lavaplayer/demo/d4j/AudioProvider.java
+++ b/demo-d4j/src/main/java/com/sedmelluq/discord/lavaplayer/demo/d4j/AudioProvider.java
@@ -2,6 +2,8 @@ package com.sedmelluq.discord.lavaplayer.demo.d4j;
 
 import com.sedmelluq.discord.lavaplayer.player.AudioPlayer;
 import com.sedmelluq.discord.lavaplayer.track.playback.AudioFrame;
+
+import sx.blah.discord.handle.audio.AudioEncodingType;
 import sx.blah.discord.handle.audio.IAudioProvider;
 
 /**


### PR DESCRIPTION
Class sx.blah.discord.handle.audio.AudioEncodingType was used but not imported in one of the Discord4J example classes.