### PR TITLE
Icecast Stream Metadata

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/AbstractMediaContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/AbstractMediaContainerProbe.java
@@ -23,10 +23,11 @@ public abstract class AbstractMediaContainerProbe implements MediaContainerProbe
    */
   protected String getDefaultTitle(SeekableInputStream inputStream) {
     PersistentHttpStream httpStream = getHttpStream(inputStream);
+    String title = null;
     if (httpStream != null) {
-      return getHeaderValue(httpStream.getCurrentResponse(), "icy-description");
+      title = getHeaderValue(httpStream.getCurrentResponse(), "icy-description");
     }
-    return UNKNOWN_TITLE;
+    return defaultOnNull(title, UNKNOWN_TITLE);
   }
 
   /**
@@ -37,15 +38,15 @@ public abstract class AbstractMediaContainerProbe implements MediaContainerProbe
    * @return Track Artist
    */
   protected String getDefaultArtist(SeekableInputStream inputStream) {
-    String title = null;
+    String artist = null;
     PersistentHttpStream httpStream = getHttpStream(inputStream);
     if (httpStream != null) {
-      title = getHeaderValue(httpStream.getCurrentResponse(), "icy-name");
-      if (title == null) {
-        title = getHeaderValue(httpStream.getCurrentResponse(), "icy-url");
+      artist = getHeaderValue(httpStream.getCurrentResponse(), "icy-name");
+      if (artist == null) {
+        artist = getHeaderValue(httpStream.getCurrentResponse(), "icy-url");
       }
     }
-    return defaultOnNull(title, UNKNOWN_ARTIST);
+    return defaultOnNull(artist, UNKNOWN_ARTIST);
   }
 
   /**

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/AbstractMediaContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/AbstractMediaContainerProbe.java
@@ -1,0 +1,79 @@
+package com.sedmelluq.discord.lavaplayer.container;
+
+import com.sedmelluq.discord.lavaplayer.tools.io.PersistentHttpStream;
+import com.sedmelluq.discord.lavaplayer.tools.io.SavedHeadSeekableInputStream;
+import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
+
+import static com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools.getHeaderValue;
+import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
+import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
+import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
+
+/**
+ * Abstract container detection probe
+ */
+public abstract class AbstractMediaContainerProbe implements MediaContainerProbe {
+
+  /**
+   * Attempts to extract track title from HTTP response headers.
+   * It other case returns default {@link UNKNOWN_TITLE}
+   *
+   * @param inputStream Input stream that contains the track file
+   * @return Track Title
+   */
+  protected String getDefaultTitle(SeekableInputStream inputStream) {
+    PersistentHttpStream httpStream = getHttpStream(inputStream);
+    if (httpStream != null) {
+      return getHeaderValue(httpStream.getCurrentResponse(), "icy-description");
+    }
+    return UNKNOWN_TITLE;
+  }
+
+  /**
+   * Attempts to extract track artist from HTTP response headers.
+   * It other case returns default {@link UNKNOWN_ARTIST}
+   *
+   * @param inputStream Input stream that contains the track file
+   * @return Track Artist
+   */
+  protected String getDefaultArtist(SeekableInputStream inputStream) {
+    String title = null;
+    PersistentHttpStream httpStream = getHttpStream(inputStream);
+    if (httpStream != null) {
+      title = getHeaderValue(httpStream.getCurrentResponse(), "icy-name");
+      if (title == null) {
+        title = getHeaderValue(httpStream.getCurrentResponse(), "icy-url");
+      }
+    }
+    return defaultOnNull(title, UNKNOWN_ARTIST);
+  }
+
+  /**
+   * Attempts to extract track url from HTTP response headers.
+
+   * @param inputStream Input stream that contains the track file
+   * @return Url
+   */
+  protected String getDefaultUrl(SeekableInputStream inputStream) {
+    PersistentHttpStream httpStream = getHttpStream(inputStream);
+    if (httpStream != null) {
+      return getHeaderValue(httpStream.getCurrentResponse(), "icy-url");
+    }
+    return null;
+  }
+
+  /**
+   * Returns HTTP stream if present as current class or underlaying delegate of {@link SavedHeadSeekableInputStream}
+   * @param inputStream Input stream that contains the track file
+   * @return An {@link PersistentHttpStream} stream object
+   */
+  private PersistentHttpStream getHttpStream(SeekableInputStream inputStream) {
+    if (inputStream instanceof SavedHeadSeekableInputStream) {
+      inputStream = ((SavedHeadSeekableInputStream) inputStream).getDelegate();
+    }
+    if (inputStream instanceof PersistentHttpStream) {
+      return (PersistentHttpStream) inputStream;
+    }
+    return null;
+  }
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/adts/AdtsContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/adts/AdtsContainerProbe.java
@@ -3,7 +3,7 @@ package com.sedmelluq.discord.lavaplayer.container.adts;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -13,10 +13,12 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
+import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
+
 /**
  * Container detection probe for ADTS stream format.
  */
-public class AdtsContainerProbe implements MediaContainerProbe {
+public class AdtsContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(AdtsContainerProbe.class);
 
   @Override
@@ -40,12 +42,12 @@ public class AdtsContainerProbe implements MediaContainerProbe {
     log.debug("Track {} is an ADTS stream.", reference.identifier);
 
     return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-        reference.title != null ? reference.title : MediaContainerDetection.UNKNOWN_TITLE,
-        MediaContainerDetection.UNKNOWN_ARTIST,
+        reference.title != null ? reference.title : getDefaultTitle(inputStream),
+        getDefaultArtist(inputStream),
         Long.MAX_VALUE,
         reference.identifier,
         true,
-        reference.identifier
+        defaultOnNull(getDefaultUrl(inputStream), reference.identifier)
     ));
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/flac/FlacContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/flac/FlacContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.flac;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -12,15 +12,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
 import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
 
 /**
  * Container detection probe for MP3 format.
  */
-public class FlacContainerProbe implements MediaContainerProbe {
+public class FlacContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(FlacContainerProbe.class);
 
   private static final String TITLE_TAG = "TITLE";
@@ -47,12 +45,12 @@ public class FlacContainerProbe implements MediaContainerProbe {
     FlacTrackInfo trackInfo = new FlacFileLoader(inputStream).parseHeaders();
 
     return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-        defaultOnNull(trackInfo.tags.get(TITLE_TAG), UNKNOWN_TITLE),
-        defaultOnNull(trackInfo.tags.get(ARTIST_TAG), UNKNOWN_ARTIST),
+        defaultOnNull(trackInfo.tags.get(TITLE_TAG), getDefaultTitle(inputStream)),
+        defaultOnNull(trackInfo.tags.get(ARTIST_TAG), getDefaultArtist(inputStream)),
         trackInfo.duration,
         reference.identifier,
         false,
-        reference.identifier
+        defaultOnNull(getDefaultUrl(inputStream), reference.identifier)
     ));
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/matroska/MatroskaContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.matroska;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.matroska.format.MatroskaFileTrack;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
@@ -15,14 +15,13 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
+import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
 
 /**
  * Container detection probe for matroska format.
  */
-public class MatroskaContainerProbe implements MediaContainerProbe {
+public class MatroskaContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(MatroskaContainerProbe.class);
 
   static final String OPUS_CODEC = "A_OPUS";
@@ -57,8 +56,13 @@ public class MatroskaContainerProbe implements MediaContainerProbe {
       return new MediaContainerDetectionResult(this, "No supported audio tracks present in the file.");
     }
 
-    return new MediaContainerDetectionResult(this, new AudioTrackInfo(UNKNOWN_TITLE, UNKNOWN_ARTIST,
-        (long) file.getDuration(), reference.identifier, false, reference.identifier));
+    return new MediaContainerDetectionResult(this, new AudioTrackInfo(
+        getDefaultTitle(inputStream),
+        getDefaultArtist(inputStream),
+        (long) file.getDuration(),
+        reference.identifier,
+        false,
+        defaultOnNull(getDefaultUrl(inputStream), reference.identifier)));
   }
 
   private boolean hasSupportedAudioTrack(MatroskaStreamingFile file) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3ContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mp3/Mp3ContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.mp3;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -13,15 +13,13 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.STREAM_SCAN_DISTANCE;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
 import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
 
 /**
  * Container detection probe for MP3 format.
  */
-public class Mp3ContainerProbe implements MediaContainerProbe {
+public class Mp3ContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(Mp3ContainerProbe.class);
 
   private static final int[] ID3_TAG = new int[] { 0x49, 0x44, 0x33 };
@@ -60,12 +58,12 @@ public class Mp3ContainerProbe implements MediaContainerProbe {
       file.parseHeaders();
 
       return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-          defaultOnNull(file.getIdv3Tag(TITLE_TAG), reference.title != null ? reference.title : UNKNOWN_TITLE),
-          defaultOnNull(file.getIdv3Tag(ARTIST_TAG), UNKNOWN_ARTIST),
+          defaultOnNull(file.getIdv3Tag(TITLE_TAG), reference.title != null ? reference.title : getDefaultTitle(inputStream)),
+          defaultOnNull(file.getIdv3Tag(ARTIST_TAG), getDefaultArtist(inputStream)),
           file.getDuration(),
           reference.identifier,
           !file.isSeekable(),
-          reference.identifier
+          defaultOnNull(getDefaultUrl(inputStream), reference.identifier)
       ));
     } finally {
       file.close();

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mpeg/MpegContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/mpeg/MpegContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.mpeg;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.mpeg.reader.MpegFileTrackProvider;
 import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
@@ -14,14 +14,13 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
+import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
 
 /**
  * Container detection probe for MP4 format.
  */
-public class MpegContainerProbe implements MediaContainerProbe {
+public class MpegContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(MpegContainerProbe.class);
 
   private static final int[] ISO_TAG = new int[] { 0x00, 0x00, 0x00, -1, 0x66, 0x74, 0x79, 0x70 };
@@ -61,12 +60,12 @@ public class MpegContainerProbe implements MediaContainerProbe {
     }
 
     return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-        DataFormatTools.defaultOnNull(file.getTextMetadata("Title"), UNKNOWN_TITLE),
-        DataFormatTools.defaultOnNull(file.getTextMetadata("Artist"), UNKNOWN_ARTIST),
+        DataFormatTools.defaultOnNull(file.getTextMetadata("Title"), getDefaultTitle(inputStream)),
+        DataFormatTools.defaultOnNull(file.getTextMetadata("Artist"), getDefaultArtist(inputStream)),
         fileReader.getDuration(),
         reference.identifier,
         false,
-        reference.identifier
+        defaultOnNull(getDefaultUrl(inputStream), reference.identifier)
     ));
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/OggContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/ogg/OggContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.ogg;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -12,15 +12,14 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
 import static com.sedmelluq.discord.lavaplayer.container.ogg.OggPacketInputStream.OGG_PAGE_HEADER;
+import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
 
 /**
  * Container detection probe for OGG stream.
  */
-public class OggContainerProbe implements MediaContainerProbe {
+public class OggContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(OggContainerProbe.class);
 
   @Override
@@ -42,12 +41,12 @@ public class OggContainerProbe implements MediaContainerProbe {
     log.debug("Track {} is an OGG stream.", reference.identifier);
 
     return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-        reference.title != null ? reference.title : UNKNOWN_TITLE,
-        UNKNOWN_ARTIST,
+        reference.title != null ? reference.title : getDefaultTitle(stream),
+        getDefaultArtist(stream),
         Long.MAX_VALUE,
         reference.identifier,
         true,
-        reference.identifier
+        defaultOnNull(getDefaultUrl(stream), reference.identifier)
     ));
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/M3uPlaylistContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/playlists/M3uPlaylistContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.playlists;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.DataFormatTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
@@ -19,7 +19,7 @@ import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection
 /**
  * Probe for M3U playlist.
  */
-public class M3uPlaylistContainerProbe implements MediaContainerProbe {
+public class M3uPlaylistContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(M3uPlaylistContainerProbe.class);
 
   private static final int[] M3U_HEADER_TAG = new int[] { '#', 'E', 'X', 'T', 'M', '3', 'U' };

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/wav/WavContainerProbe.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/container/wav/WavContainerProbe.java
@@ -1,8 +1,8 @@
 package com.sedmelluq.discord.lavaplayer.container.wav;
 
+import com.sedmelluq.discord.lavaplayer.container.AbstractMediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerDetectionResult;
 import com.sedmelluq.discord.lavaplayer.container.MediaContainerHints;
-import com.sedmelluq.discord.lavaplayer.container.MediaContainerProbe;
 import com.sedmelluq.discord.lavaplayer.tools.io.SeekableInputStream;
 import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
@@ -12,8 +12,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_ARTIST;
-import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.UNKNOWN_TITLE;
 import static com.sedmelluq.discord.lavaplayer.container.MediaContainerDetection.checkNextBytes;
 import static com.sedmelluq.discord.lavaplayer.container.wav.WavFileLoader.WAV_RIFF_HEADER;
 import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNull;
@@ -21,7 +19,7 @@ import static com.sedmelluq.discord.lavaplayer.tools.DataFormatTools.defaultOnNu
 /**
  * Container detection probe for WAV format.
  */
-public class WavContainerProbe implements MediaContainerProbe {
+public class WavContainerProbe extends AbstractMediaContainerProbe {
   private static final Logger log = LoggerFactory.getLogger(WavContainerProbe.class);
 
   @Override
@@ -45,12 +43,12 @@ public class WavContainerProbe implements MediaContainerProbe {
     WavFileInfo fileInfo = new WavFileLoader(inputStream).parseHeaders();
 
     return new MediaContainerDetectionResult(this, new AudioTrackInfo(
-        defaultOnNull(reference.title, UNKNOWN_TITLE),
-        UNKNOWN_ARTIST,
+        defaultOnNull(reference.title, getDefaultTitle(inputStream)),
+        getDefaultArtist(inputStream),
         fileInfo.getDuration(),
         reference.identifier,
         false,
-        reference.identifier
+        defaultOnNull(getDefaultUrl(inputStream), reference.identifier)
     ));
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/SavedHeadSeekableInputStream.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/SavedHeadSeekableInputStream.java
@@ -34,6 +34,14 @@ public class SavedHeadSeekableInputStream extends SeekableInputStream {
     headPosition = 0;
   }
 
+  /**
+   * Return the delegate stream of this wrapper
+   * @return Delegate stream
+   */
+  public SeekableInputStream getDelegate() {
+    return delegate;
+  }
+
   @Override
   public long getPosition() {
     if (usingHead) {


### PR DESCRIPTION
In order to show something greater than just `Unknown Title / Unknown Artist` for http stream urls, we can grab some metadata from response headers as fallback if there is no metadata from the stream itself. Here are support for Icecast `icy-*` metadata.