### PR TITLE
Remove hard-coded maximum volume limit

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -274,7 +274,7 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   }
 
   public void setVolume(int volume) {
-    options.volumeLevel.set(Math.min(150, Math.max(0, volume)));
+    options.volumeLevel.set(Math.max(0, volume));
   }
 
   public void setFilterFactory(PcmFilterFactory factory) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -274,7 +274,7 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
   }
 
   public void setVolume(int volume) {
-    options.volumeLevel.set(Math.max(0, volume));
+    options.volumeLevel.set(Math.min(1000, Math.max(0, volume)));
   }
 
   public void setFilterFactory(PcmFilterFactory factory) {


### PR DESCRIPTION
Some older songs on YouTube (usually dated before 2009) are usually quieter in terms of volume. 150 sometimes isn't enough to compensate for the lacking volume. This PR removes the hard-coded limit in favor of allowing developers to set their own limits.