### PR TITLE
More arch detection, read lib locations, etc. from properties

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,11 +7,12 @@ plugins {
 apply plugin: 'com.jfrog.bintray'
 
 ext.moduleName = 'lavaplayer-common'
-version = '1.0.6'
+version = '1.1.0'
 
 dependencies {
   compile "org.slf4j:slf4j-api:$slf4jVersion"
   compile 'commons-io:commons-io:2.6'
+  compile 'commons-lang:commons-lang:2.6'
 }
 
 compileJava.dependsOn(':natives:checkNatives')

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -12,7 +12,6 @@ version = '1.1.0'
 dependencies {
   compile "org.slf4j:slf4j-api:$slf4jVersion"
   compile 'commons-io:commons-io:2.6'
-  compile 'commons-lang:commons-lang:2.6'
 }
 
 compileJava.dependsOn(':natives:checkNatives')

--- a/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/Architecture.java
+++ b/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/Architecture.java
@@ -1,0 +1,135 @@
+package com.sedmelluq.discord.lavaplayer.natives;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class Architecture {
+  private static final String OS_DARWIN = "darwin";
+  private static final String OS_LINUX = "linux";
+  private static final String OS_OSX = "osx";
+  private static final String OS_SOLARIS = "solaris";
+  private static final String OS_WINDOWS = "win";
+
+  private static final String ARCH_ARM = "arm";
+  private static final String ARCH_ARM_HF = "armhf";
+  private static final String ARCH_ARMv8_32 = "aarch32";
+  private static final String ARCH_ARMv8_64 = "aarch64";
+  private static final String ARCH_MIPS_32 = "mips";
+  private static final String ARCH_MIPS_32_LE = "mipsel";
+  private static final String ARCH_MIPS_64 = "mips64";
+  private static final String ARCH_MIPS_64_LE = "mips64el";
+  private static final String ARCH_PPC_32 = "powerpc";
+  private static final String ARCH_PPC_32_LE = "powerpcle";
+  private static final String ARCH_PPC_64 = "ppc64";
+  private static final String ARCH_PPC_64_LE = "ppc64le";
+  private static final String ARCH_X86_32 = "x86";
+  private static final String ARCH_X86_64 = "x86-64";
+
+  private static final Map<String, String> abiAliasMap = new HashMap<String, String>() {{
+    put("arm", ARCH_ARM);
+    put("armeabi", ARCH_ARM);
+    put("armv7b", ARCH_ARM);
+    put("armv7l", ARCH_ARM);
+
+    put("armeabihf", ARCH_ARM_HF);
+    put("armeabi-v7a", ARCH_ARM_HF);
+
+    put("armv8b", ARCH_ARMv8_32);
+    put("armv8l", ARCH_ARMv8_32);
+
+    put("arm64", ARCH_ARMv8_64);
+    put("aarch64", ARCH_ARMv8_64);
+    put("aarch64_be", ARCH_ARMv8_64);
+    put("arm64-v8a", ARCH_ARMv8_64);
+
+    put("mips", ARCH_MIPS_32);
+    put("mipsel", ARCH_MIPS_32_LE);
+    put("mipsle", ARCH_MIPS_32_LE);
+    put("mips64", ARCH_MIPS_64);
+    put("mips64el", ARCH_MIPS_64_LE);
+    put("mips64le", ARCH_MIPS_64_LE);
+
+    put("ppc", ARCH_PPC_32);
+    put("powerpc", ARCH_PPC_32);
+    put("ppcel", ARCH_PPC_32_LE);
+    put("ppcle", ARCH_PPC_32_LE);
+    put("ppc64", ARCH_PPC_64);
+    put("ppc64el", ARCH_PPC_64_LE);
+    put("ppc64le", ARCH_PPC_64_LE);
+
+    put("x86", ARCH_X86_32);
+    put("i386", ARCH_X86_32);
+    put("i486", ARCH_X86_32);
+    put("i586", ARCH_X86_32);
+    put("i686", ARCH_X86_32);
+
+    put("x86_64", ARCH_X86_64);
+    put("amd64", ARCH_X86_64);
+  }};
+
+  public final String systemType;
+  public final String libraryPrefix;
+  public final String librarySuffix;
+
+  private static String formatSystemName(String osName, String archName) {
+    if (osName == OS_OSX && archName == ARCH_X86_64) {
+      return OS_DARWIN;
+    } else {
+      return osName + "-" + archName;
+    }
+  }
+
+  public String formatLibraryName(String libName) {
+    return this.libraryPrefix + libName + this.librarySuffix;
+  }
+
+  public static Architecture detectArchitecture() throws IllegalStateException, IllegalArgumentException {
+    String systemType = System.getProperty("lavaplayer.native.system");
+    String libPrefix, libSuffix;
+
+    if (systemType == null) {
+      final String _os_arch = System.getProperty("os.arch");
+      final String _os_name = System.getProperty("os.name");
+      String osName;
+      String archName = System.getProperty("lavaplayer.native.arch", abiAliasMap.get(_os_arch));
+
+      if (archName == null) {
+        throw new IllegalArgumentException("Unknown architecture: " + _os_arch);
+      }
+
+      if (_os_name.startsWith("Windows")) {
+        osName = OS_WINDOWS;
+        libPrefix = "";
+        libSuffix = ".dll";
+      } else if (_os_name.startsWith("Mac OS X")) {
+        osName = OS_OSX;
+        libPrefix = "lib";
+        libSuffix = ".dylib";
+      } else if (_os_name.startsWith("Solaris")) {
+        osName = OS_SOLARIS;
+        libPrefix = "lib";
+        libSuffix = ".so";
+      } else if (_os_name.toLowerCase().startsWith("linux")) {
+        osName = OS_LINUX;
+        libPrefix = "lib";
+        libSuffix = ".so";
+      } else {
+        throw new IllegalArgumentException("Unknown operating system: " + _os_name);
+      }
+
+      systemType = formatSystemName(osName, archName);
+    } else {
+      // Assume UNIX library filename conventions
+      libPrefix = System.getProperty("lavaplayer.native.libPrefix", "lib");
+      libSuffix = System.getProperty("lavaplayer.native.libSuffix", ".so");
+    }
+
+    return new Architecture(systemType, libPrefix, libSuffix);
+  }
+
+  private Architecture(String systemType, String libraryPrefix, String librarySuffix) {
+    this.systemType = systemType;
+    this.libraryPrefix = libraryPrefix;
+    this.librarySuffix = librarySuffix;
+  }
+}

--- a/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
+++ b/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
@@ -10,9 +10,7 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
@@ -22,71 +20,8 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
  * Loads native libraries by name. Libraries are expected to be in classpath /natives/[arch]/[prefix]name[suffix]
  */
 public class NativeLibLoader {
-  public static final String OS_DARWIN = "darwin";
-  public static final String OS_LINUX = "linux";
-  public static final String OS_OSX = "osx";
-  public static final String OS_SOLARIS = "solaris";
-  public static final String OS_WINDOWS = "win";
-
-  public static final String ARCH_ARM = "arm";
-  public static final String ARCH_ARM_HF = "armhf";
-  public static final String ARCH_ARMv8_32 = "aarch32";
-  public static final String ARCH_ARMv8_64 = "aarch64";
-  public static final String ARCH_MIPS_32 = "mips";
-  public static final String ARCH_MIPS_32_LE = "mipsel";
-  public static final String ARCH_MIPS_64 = "mips64";
-  public static final String ARCH_MIPS_64_LE = "mips64el";
-  public static final String ARCH_PPC_32 = "powerpc";
-  public static final String ARCH_PPC_32_LE = "powerpcle";
-  public static final String ARCH_PPC_64 = "ppc64";
-  public static final String ARCH_PPC_64_LE = "ppc64le";
-  public static final String ARCH_X86_32 = "x86";
-  public static final String ARCH_X86_64 = "x86-64";
-
-  public static final Map<String, String> archMap = new HashMap<String, String>() {{
-    put("arm", ARCH_ARM);
-    put("armeabi", ARCH_ARM);
-    put("armv7b", ARCH_ARM);
-    put("armv7l", ARCH_ARM);
-
-    put("armeabihf", ARCH_ARM_HF);
-    put("armeabi-v7a", ARCH_ARM_HF);
-
-    put("armv8b", ARCH_ARMv8_32);
-    put("armv8l", ARCH_ARMv8_32);
-
-    put("arm64", ARCH_ARMv8_64);
-    put("aarch64", ARCH_ARMv8_64);
-    put("aarch64_be", ARCH_ARMv8_64);
-    put("arm64-v8a", ARCH_ARMv8_64);
-
-    put("mips", ARCH_MIPS_32);
-    put("mipsel", ARCH_MIPS_32_LE);
-    put("mipsle", ARCH_MIPS_32_LE);
-    put("mips64", ARCH_MIPS_64);
-    put("mips64el", ARCH_MIPS_64_LE);
-    put("mips64le", ARCH_MIPS_64_LE);
-
-    put("ppc", ARCH_PPC_32);
-    put("powerpc", ARCH_PPC_32);
-    put("ppcel", ARCH_PPC_32_LE);
-    put("ppcle", ARCH_PPC_32_LE);
-    put("ppc64", ARCH_PPC_64);
-    put("ppc64el", ARCH_PPC_64_LE);
-    put("ppc64le", ARCH_PPC_64_LE);
-
-    put("x86", ARCH_X86_32);
-    put("i386", ARCH_X86_32);
-    put("i486", ARCH_X86_32);
-    put("i586", ARCH_X86_32);
-    put("i686", ARCH_X86_32);
-
-    put("x86_64", ARCH_X86_64);
-    put("amd64", ARCH_X86_64);
-  }};
-
   private static final Set<String> loadedLibraries = new HashSet<>();
-  private static final String tempDir = String.valueOf(System.currentTimeMillis());
+  private static File extractionDirectory = new File(System.getProperty("java.io.tmpdir"), "lava-jni-natives/" + String.valueOf(System.currentTimeMillis()));
   private static final Architecture architecture = Architecture.detectArchitecture();
 
   /**
@@ -139,6 +74,8 @@ public class NativeLibLoader {
             libPath = new File(archRoot, architecture.formatLibraryName(name)).getAbsolutePath();
           } else if (libPath == null) {
             libPath = extractLibrary(resourceBase, name).toFile().getAbsolutePath();
+          } else {
+            libPath = new File(libPath).getAbsolutePath();
           }
           System.load(libPath);
           loadedLibraries.add(name);
@@ -158,11 +95,9 @@ public class NativeLibLoader {
         throw new UnsatisfiedLinkError("Required library at " + path + " was not found");
       }
 
-      File temporaryContainer = new File(System.getProperty("java.io.tmpdir"), "lava-jni-natives/" + tempDir);
-
-      if (!temporaryContainer.exists()) {
+      if (!extractionDirectory.exists()) {
         try {
-          createDirectoriesWithFullPermissions(temporaryContainer.toPath());
+          createDirectoriesWithFullPermissions(extractionDirectory.toPath());
         } catch (FileAlreadyExistsException ignored) {
           // All is well
         } catch (IOException e) {
@@ -170,7 +105,7 @@ public class NativeLibLoader {
         }
       }
 
-      extractedLibrary = new File(temporaryContainer, architecture.formatLibraryName(name)).toPath();
+      extractedLibrary = new File(extractionDirectory, architecture.formatLibraryName(name)).toPath();
       try (FileOutputStream fileStream = new FileOutputStream(extractedLibrary.toFile())) {
         IOUtils.copy(libraryStream, fileStream);
       }
@@ -186,68 +121,6 @@ public class NativeLibLoader {
       Files.createDirectories(path);
     } else {
       Files.createDirectories(path, asFileAttribute(fromString("rwxrwxrwx")));
-    }
-  }
-
-  private static class Architecture {
-    private final String osName;
-    private final String archName;
-    private final String libraryPrefix;
-    private final String librarySuffix;
-    private final String systemType;
-
-    private static String formatSystemName(String osName, String archName) {
-      if (osName == OS_OSX && archName == ARCH_X86_64) {
-        return OS_DARWIN;
-      } else {
-        return osName + "-" + archName;
-      }
-    }
-
-    public String formatLibraryName(String libName) {
-      return this.libraryPrefix + libName + this.librarySuffix;
-    }
-
-    public static Architecture detectArchitecture() throws IllegalStateException, IllegalArgumentException {
-      final String _os_arch = System.getProperty("os.arch");
-      final String _os_name = System.getProperty("os.name");
-      String archName = System.getProperty("lavaplayer.native.arch", archMap.get(_os_arch));
-      String osName, libPrefix, libSuffix;
-
-      if (archName == null) {
-        throw new IllegalArgumentException("Unknown architecture: " + _os_arch);
-      }
-
-      if (_os_name.startsWith("Windows")) {
-        osName = OS_WINDOWS;
-        libPrefix = "";
-        libSuffix = ".dll";
-      } else if (_os_name.startsWith("Mac OS X")) {
-        osName = OS_OSX;
-        libPrefix = "lib";
-        libSuffix = ".dylib";
-      } else if (_os_name.startsWith("Solaris")) {
-        osName = OS_SOLARIS;
-        libPrefix = "lib";
-        libSuffix = ".so";
-      } else if (_os_name.toLowerCase().startsWith("linux")) {
-        osName = OS_LINUX;
-        libPrefix = "lib";
-        libSuffix = ".so";
-      } else {
-        throw new IllegalArgumentException("Unknown operating system: " + _os_name);
-      }
-
-      return new Architecture(osName, archName, libPrefix, libSuffix);
-    }
-
-    private Architecture(String osName, String archName, String libraryPrefix, String librarySuffix) {
-      this.osName = osName;
-      this.archName = archName;
-      this.libraryPrefix = libraryPrefix;
-      this.librarySuffix = librarySuffix;
-
-      this.systemType = System.getProperty("lavaplayer.native.system", formatSystemName(osName, archName));
     }
   }
 }

--- a/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
+++ b/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
@@ -1,6 +1,7 @@
 package com.sedmelluq.discord.lavaplayer.natives;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.SystemUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -10,7 +11,9 @@ import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import static java.nio.file.attribute.PosixFilePermissions.asFileAttribute;
@@ -20,17 +23,72 @@ import static java.nio.file.attribute.PosixFilePermissions.fromString;
  * Loads native libraries by name. Libraries are expected to be in classpath /natives/[arch]/[prefix]name[suffix]
  */
 public class NativeLibLoader {
-  public static final String LINUX_X86 = "linux-x86";
-  public static final String LINUX_X86_64 = "linux-x86-64";
-  public static final String LINUX_ARM = "linux-arm";
-  public static final String LINUX_ARM_64 = "linux-aarch64";
-  public static final String WIN_X86 = "win-x86";
-  public static final String WIN_X86_64 = "win-x86-64";
-  public static final String DARWIN = "darwin";
+  public static final String OS_DARWIN = "darwin";
+  public static final String OS_LINUX = "linux";
+  public static final String OS_OSX = "osx";
+  public static final String OS_SOLARIS = "solaris";
+  public static final String OS_WINDOWS = "win";
+
+  public static final String ARCH_ARM = "arm";
+  public static final String ARCH_ARM_HF = "armhf";
+  public static final String ARCH_ARMv8_32 = "aarch32";
+  public static final String ARCH_ARMv8_64 = "aarch64";
+  public static final String ARCH_MIPS_32 = "mips";
+  public static final String ARCH_MIPS_32_LE = "mipsel";
+  public static final String ARCH_MIPS_64 = "mips64";
+  public static final String ARCH_MIPS_64_LE = "mips64el";
+  public static final String ARCH_PPC_32 = "powerpc";
+  public static final String ARCH_PPC_32_LE = "powerpcle";
+  public static final String ARCH_PPC_64 = "ppc64";
+  public static final String ARCH_PPC_64_LE = "ppc64le";
+  public static final String ARCH_X86_32 = "x86";
+  public static final String ARCH_X86_64 = "x86-64";
+
+  public static final Map<String, String> archMap = new HashMap<String, String>() {{
+    put("arm", ARCH_ARM);
+    put("armeabi", ARCH_ARM);
+    put("armv7b", ARCH_ARM);
+    put("armv7l", ARCH_ARM);
+
+    put("armeabihf", ARCH_ARM_HF);
+    put("armeabi-v7a", ARCH_ARM_HF);
+
+    put("armv8b", ARCH_ARMv8_32);
+    put("armv8l", ARCH_ARMv8_32);
+
+    put("arm64", ARCH_ARMv8_64);
+    put("aarch64", ARCH_ARMv8_64);
+    put("aarch64_be", ARCH_ARMv8_64);
+    put("arm64-v8a", ARCH_ARMv8_64);
+
+    put("mips", ARCH_MIPS_32);
+    put("mipsel", ARCH_MIPS_32_LE);
+    put("mipsle", ARCH_MIPS_32_LE);
+    put("mips64", ARCH_MIPS_64);
+    put("mips64el", ARCH_MIPS_64_LE);
+    put("mips64le", ARCH_MIPS_64_LE);
+
+    put("ppc", ARCH_PPC_32);
+    put("powerpc", ARCH_PPC_32);
+    put("ppcel", ARCH_PPC_32_LE);
+    put("ppcle", ARCH_PPC_32_LE);
+    put("ppc64", ARCH_PPC_64);
+    put("ppc64el", ARCH_PPC_64_LE);
+    put("ppc64le", ARCH_PPC_64_LE);
+
+    put("x86", ARCH_X86_32);
+    put("i386", ARCH_X86_32);
+    put("i486", ARCH_X86_32);
+    put("i586", ARCH_X86_32);
+    put("i686", ARCH_X86_32);
+
+    put("x86_64", ARCH_X86_64);
+    put("amd64", ARCH_X86_64);
+  }};
 
   private static final Set<String> loadedLibraries = new HashSet<>();
-  private static final String libraryDirectory = String.valueOf(System.currentTimeMillis());
-  private static final Architecture architecture = detectArchitecture();
+  private static final String tempDir = String.valueOf(System.currentTimeMillis());
+  private static final Architecture architecture = Architecture.detectArchitecture();
 
   /**
    * Load a library only if the current system type matches the specified one
@@ -59,7 +117,7 @@ public class NativeLibLoader {
    * @param systemTypeFilter System type that should match current
    * @throws LinkageError When loading the library fails
    */
-  public static void load(Class<?> resourceBase, String name, String systemTypeFilter) {
+  public static void load(Class<?> resourceBase, String name, String systemTypeFilter) throws LinkageError {
     if (architecture.systemType.equals(systemTypeFilter)) {
       load(resourceBase, name);
     }
@@ -70,12 +128,20 @@ public class NativeLibLoader {
    * @param name Name of the library
    * @throws LinkageError When loading the library fails
    */
-  public static void load(Class<?> resourceBase, String name) {
+  public static void load(Class<?> resourceBase, String name) throws LinkageError, UnsatisfiedLinkError {
     synchronized (loadedLibraries) {
       if (!loadedLibraries.contains(name)) {
-        try {
-          System.load(extractLibrary(resourceBase, name).toFile().getAbsolutePath());
+        String libPath = System.getProperty("lavaplayer." + name + ".path");
+        String libRoot = System.getProperty("lavaplayer.native.dir");
 
+        try {
+          if (libRoot != null) {
+            File archRoot = new File(libRoot, architecture.systemType);
+            libPath = new File(archRoot, architecture.formatLibraryName(name)).getAbsolutePath();
+          } else if (libPath == null) {
+            libPath = extractLibrary(resourceBase, name).toFile().getAbsolutePath();
+          }
+          System.load(libPath);
           loadedLibraries.add(name);
         } catch (Exception e) {
           throw new LinkageError("Failed to load native library due to an exception.", e);
@@ -85,7 +151,7 @@ public class NativeLibLoader {
   }
 
   private static Path extractLibrary(Class<?> resourceBase, String name) throws IOException {
-    String path = "/natives/" + architecture.systemType + "/" + architecture.libraryPrefix + name + architecture.librarySuffix;
+    String path = "/natives/" + architecture.systemType + "/" + architecture.formatLibraryName(name);
     Path extractedLibrary;
 
     try (InputStream libraryStream = resourceBase.getResourceAsStream(path)) {
@@ -93,7 +159,7 @@ public class NativeLibLoader {
         throw new UnsatisfiedLinkError("Required library at " + path + " was not found");
       }
 
-      File temporaryContainer = new File(System.getProperty("java.io.tmpdir"), "lava-jni-natives/" + libraryDirectory);
+      File temporaryContainer = new File(System.getProperty("java.io.tmpdir"), "lava-jni-natives/" + tempDir);
 
       if (!temporaryContainer.exists()) {
         try {
@@ -105,7 +171,7 @@ public class NativeLibLoader {
         }
       }
 
-      extractedLibrary = new File(temporaryContainer, architecture.libraryPrefix + name + architecture.librarySuffix).toPath();
+      extractedLibrary = new File(temporaryContainer, architecture.formatLibraryName(name)).toPath();
       try (FileOutputStream fileStream = new FileOutputStream(extractedLibrary.toFile())) {
         IOUtils.copy(libraryStream, fileStream);
       }
@@ -124,37 +190,63 @@ public class NativeLibLoader {
     }
   }
 
-  private static Architecture detectArchitecture() {
-    String osName = System.getProperty("os.name");
-    String arch = System.getProperty("os.arch");
-    String bits = System.getProperty("sun.arch.data.model");
-
-    if (osName.startsWith("Linux")) {
-      if (arch.startsWith("arm")) {
-        return new Architecture(LINUX_ARM, "lib", ".so");
-      } else if (arch.startsWith("aarch64")) {
-        return new Architecture(LINUX_ARM_64, "lib", ".so");
-      } else {
-        return new Architecture("64".equals(bits) ? LINUX_X86_64 : LINUX_X86, "lib", ".so");
-      }
-    } else if ((osName.startsWith("Mac") || osName.startsWith("Darwin")) && "64".equals(bits)) {
-      return new Architecture(DARWIN, "lib", ".dylib");
-    } else if (osName.startsWith("Windows") && !osName.startsWith("Windows CE")) {
-      return new Architecture("64".equals(bits) ? WIN_X86_64 : WIN_X86, "", ".dll");
-    }
-
-    throw new IllegalStateException("Native libraries not supported on this platform.");
-  }
-
   private static class Architecture {
-    private final String systemType;
+    private final String osName;
+    private final String archName;
     private final String libraryPrefix;
     private final String librarySuffix;
+    private final String systemType;
 
-    private Architecture(String systemType, String libraryPrefix, String librarySuffix) {
-      this.systemType = systemType;
+    private static String formatSystemName(String osName, String archName) {
+      if (osName == OS_OSX && archName == ARCH_X86_64) {
+        return OS_DARWIN;
+      } else {
+        return osName + "-" + archName;
+      }
+    }
+
+    public String formatLibraryName(String libName) {
+      return this.libraryPrefix + libName + this.librarySuffix;
+    }
+
+    public static Architecture detectArchitecture() throws IllegalStateException, IllegalArgumentException {
+      String archName = System.getProperty("lavaplayer.native.arch", archMap.get(SystemUtils.OS_ARCH));
+      String osName, libPrefix, libSuffix;
+
+      if (archName == null) {
+        throw new IllegalArgumentException("Unknown architecture: " + SystemUtils.OS_ARCH);
+      }
+
+      if (SystemUtils.IS_OS_WINDOWS) {
+        osName = OS_WINDOWS;
+        libPrefix = "";
+        libSuffix = ".dll";
+      } else if (SystemUtils.IS_OS_MAC_OSX) {
+        osName = OS_OSX;
+        libPrefix = "lib";
+        libSuffix = ".dylib";
+      } else if (SystemUtils.IS_OS_SOLARIS) {
+        osName = OS_SOLARIS;
+        libPrefix = "lib";
+        libSuffix = ".so";
+      } else if (SystemUtils.IS_OS_LINUX) {
+        osName = OS_LINUX;
+        libPrefix = "lib";
+        libSuffix = ".so";
+      } else {
+        throw new IllegalArgumentException("Unknown operating system: " + SystemUtils.OS_NAME);
+      }
+
+      return new Architecture(osName, archName, libPrefix, libSuffix);
+    }
+
+    private Architecture(String osName, String archName, String libraryPrefix, String librarySuffix) {
+      this.osName = osName;
+      this.archName = archName;
       this.libraryPrefix = libraryPrefix;
       this.librarySuffix = librarySuffix;
+
+      this.systemType = System.getProperty("lavaplayer.native.system", formatSystemName(osName, archName));
     }
   }
 }

--- a/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
+++ b/common/src/main/java/com/sedmelluq/discord/lavaplayer/natives/NativeLibLoader.java
@@ -1,7 +1,6 @@
 package com.sedmelluq.discord.lavaplayer.natives;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.SystemUtils;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -210,31 +209,33 @@ public class NativeLibLoader {
     }
 
     public static Architecture detectArchitecture() throws IllegalStateException, IllegalArgumentException {
-      String archName = System.getProperty("lavaplayer.native.arch", archMap.get(SystemUtils.OS_ARCH));
+      final String _os_arch = System.getProperty("os.arch");
+      final String _os_name = System.getProperty("os.name");
+      String archName = System.getProperty("lavaplayer.native.arch", archMap.get(_os_arch));
       String osName, libPrefix, libSuffix;
 
       if (archName == null) {
-        throw new IllegalArgumentException("Unknown architecture: " + SystemUtils.OS_ARCH);
+        throw new IllegalArgumentException("Unknown architecture: " + _os_arch);
       }
 
-      if (SystemUtils.IS_OS_WINDOWS) {
+      if (_os_name.startsWith("Windows")) {
         osName = OS_WINDOWS;
         libPrefix = "";
         libSuffix = ".dll";
-      } else if (SystemUtils.IS_OS_MAC_OSX) {
+      } else if (_os_name.startsWith("Mac OS X")) {
         osName = OS_OSX;
         libPrefix = "lib";
         libSuffix = ".dylib";
-      } else if (SystemUtils.IS_OS_SOLARIS) {
+      } else if (_os_name.startsWith("Solaris")) {
         osName = OS_SOLARIS;
         libPrefix = "lib";
         libSuffix = ".so";
-      } else if (SystemUtils.IS_OS_LINUX) {
+      } else if (_os_name.toLowerCase().startsWith("linux")) {
         osName = OS_LINUX;
         libPrefix = "lib";
         libSuffix = ".so";
       } else {
-        throw new IllegalArgumentException("Unknown operating system: " + SystemUtils.OS_NAME);
+        throw new IllegalArgumentException("Unknown operating system: " + _os_name);
       }
 
       return new Architecture(osName, archName, libPrefix, libSuffix);


### PR DESCRIPTION
As discussed on Discord with @sedmelluq, these changes make it easy to run Lavalink and other projects that embed lavaplayer on more exotic architectures like ARM without modifying the `udp-queue` and `lavaplayer-native` jars. Instead, the native libraries can be built separately for the platform of interest, then used directly by setting a system property.

This change has been tested to work with Lavalink on:
- x86_64: Windows, OSX and Linux
- ARM: Linux on armv7 and armv8 (aarch64)

Loading of ALL native libraries through `NativeLibLoader` can now be controlled by:
- `lavaplayer.native.arch` : overrides the detected OS architecture, e.g. `armhf`, `x86`
- `lavaplayer.native.dir` : look in `{dir}/{system}/` for libraries
- `lavaplayer.native.system` : overrides the detected system, e.g. `linux-arm`
- `lavaplayer.{libname}.path` : overrides the full path for a specific library
  - The only two libraries that use NativeLibLoader thus far are `connector` and `udpqueue`.

Library filenames are determined by the operating system's conventions, e.g. `connector.dll` and `libconnector.so` for the `connector` lib.

`system` defaults to `{osname}-{arch}`, and overriding `system` takes priority over setting `arch`. Darwin/OSX has a special case, and uses just `darwin` instead of `darwin-x86-64`.

The following OSes are detected:
- Darwin (OSX): `darwin`
- Linux: `linux`
- Windows: `win`

The following architectures are detected by their names and aliases:
- `aarch32` : `armv8b`, `armv8l`
- `aarch64` :`aarch64_be`, `arm64`, `arm64-v8a`
- `arm` : `armeabi`, `armv7b`, `armv7l`
- `armhf` : `armeabihf`, `armeabi-v7a`
- `mips`
- `mipsel`
- `mips64`
- `mips64el`
- `powerpc` : `ppc`
- `ppcle` : `ppcel`
- `ppc64`
- `ppc64le` : `ppc64el`
- `x86`: `i386`, `i486`, `i586`, `i686`
- `x86-64` : `x86_64`, `amd64`

I have attached [an archive](https://github.com/sedmelluq/lavaplayer/files/2494716/natives-dockerbuild.tar.gz) with Dockerfiles and build scripts for Linux that place the built libraries in `/build/out/{arch}/`. To run them, use `docker run --rm -v $(pwd)/out:/build/out imagename [arch]...`. On a x86_64 host, the `cross` Dockerfile can build the ARM and MIPS variants, and the `x86` Dockerfile can build for x86 and x86-64. I used these Dockerfiles to build the libraries I tested this PR with. 