### PR TITLE
Fix duplicate query parameters

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -548,7 +548,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       URIBuilder builder = new URIBuilder(url);
       return new UrlInfo(builder.getPath(), builder.getQueryParams().stream()
           .filter(it -> it.getValue() != null)
-          .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue)));
+          .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue, (a, b) -> b)));
     } catch (URISyntaxException e) {
       if (retryValidPart) {
         return getUrlInfo(url.substring(0, e.getIndex() - 1), false);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -548,7 +548,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       URIBuilder builder = new URIBuilder(url);
       return new UrlInfo(builder.getPath(), builder.getQueryParams().stream()
           .filter(it -> it.getValue() != null)
-          .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue, (a, b) -> b)));
+          .collect(Collectors.toMap(NameValuePair::getName, NameValuePair::getValue, (a, b) -> a)));
     } catch (URISyntaxException e) {
       if (retryValidPart) {
         return getUrlInfo(url.substring(0, e.getIndex() - 1), false);


### PR DESCRIPTION
Duplicate query parameters such as `t=10&t=20` would cause a track to not load (due to a duplicate key exception), this makes it use the first defined query parameter with that key