### PR TITLE
Fix NPEs and playabilityStatus check

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -218,6 +218,12 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       }
 
       JsonBrowser videoDetails = JsonBrowser.parse(args.get("player_response").text()).get("videoDetails");
+
+      if (!videoDetails.isMap()) {
+        // IllegalStateException: Get only works on a map
+        log.debug("videoDetails: {}", videoDetails.format());
+      }
+
       boolean isStream = videoDetails.get("isLiveContent").as(Boolean.class);
       long duration = isStream ? Long.MAX_VALUE : videoDetails.get("lengthSeconds").as(Long.class) * 1000;
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -422,7 +422,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       } else if (reason != null) {
         throw new FriendlyException(reason, COMMON, null);
       }
-    } else if (status.equalsIgnoreCase("ok")) {
+    } else if ("ok".equalsIgnoreCase(status)) {
       return false;
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -422,7 +422,7 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       } else if (reason != null) {
         throw new FriendlyException(reason, COMMON, null);
       }
-    } else if ("ok".equals(status) || "OK".equals(status)) {
+    } else if (status.equalsIgnoreCase("ok")) {
       return false;
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -416,13 +416,13 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
   }
 
   private boolean determineFailureReasonFromStatus(String status, String reason, boolean mustExist) {
-    if ("fail".equals(status) || "ERROR".equals(status)) {
+    if ("fail".equals(status) || "ERROR".equals(status) || "UNPLAYABLE".equals(status)) {
       if (("This video does not exist.".equals(reason) || "This video is unavailable.".equals(reason)) && !mustExist) {
         return true;
       } else if (reason != null) {
         throw new FriendlyException(reason, COMMON, null);
       }
-    } else if ("ok".equals(status)) {
+    } else if ("ok".equals(status) || "OK".equals(status)) {
       return false;
     }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -204,25 +204,26 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
       }
 
       JsonBrowser args = info.get("args");
-
-      if ("fail".equals(args.get("status").text())) {
-        throw new FriendlyException(args.get("reason").text(), COMMON, null);
-      }
-
       boolean useOldFormat = args.get("player_response").isNull();
 
       if (useOldFormat) {
+        if ("fail".equals(args.get("status").text())) {
+          throw new FriendlyException(args.get("reason").text(), COMMON, null);
+        }
+
         boolean isStream = "1".equals(args.get("live_playback").text());
         long duration = isStream ? Long.MAX_VALUE : args.get("length_seconds").as(Long.class) * 1000;
         return buildTrackObject(videoId, args.get("title").text(), args.get("author").text(), isStream, duration);
       }
 
-      JsonBrowser videoDetails = JsonBrowser.parse(args.get("player_response").text()).get("videoDetails");
+      JsonBrowser playerResponse = JsonBrowser.parse(args.get("player_response").text());
+      JsonBrowser playabilityStatus = playerResponse.get("playabilityStatus");
 
-      if (!videoDetails.isMap()) {
-        // IllegalStateException: Get only works on a map
-        log.debug("videoDetails: {}", videoDetails.format());
+      if ("ERROR".equals(playabilityStatus.get("status").text())) {
+        throw new FriendlyException(playabilityStatus.get("reason").text(), COMMON, null);
       }
+
+      JsonBrowser videoDetails = playerResponse.get("videoDetails");
 
       boolean isStream = videoDetails.get("isLiveContent").as(Boolean.class);
       long duration = isStream ? Long.MAX_VALUE : videoDetails.get("lengthSeconds").as(Long.class) * 1000;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -212,7 +212,6 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     if (!formats.isNull() && formats.isList()) {
       for (JsonBrowser formatJson : formats.values()) {
-        log.debug("formatJson: {}", formatJson.format());
         String cipher = formatJson.safeGet("cipher").text();
         Map<String, String> cipherInfo = cipher != null
             ? decodeUrlEncodedItems(cipher, true)

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -182,6 +182,11 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
     for (String formatString : adaptiveFormats.split(",")) {
       Map<String, String> format = decodeUrlEncodedItems(formatString, false);
       String url = format.get("url");
+
+      if (url == null) {
+        continue;
+      }
+
       String contentLength = DataFormatTools.extractBetween(url, "clen=", "&");
 
       if (contentLength == null) {
@@ -207,15 +212,19 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
 
     if (!formats.isNull() && formats.isList()) {
       for (JsonBrowser formatJson : formats.values()) {
-        Map<String, String> cipherInfo = decodeUrlEncodedItems(formatJson.safeGet("cipher").text(), true);
+        log.debug("formatJson: {}", formatJson.format());
+        String cipher = formatJson.safeGet("cipher").text();
+        Map<String, String> cipherInfo = cipher != null
+            ? decodeUrlEncodedItems(cipher, true)
+            : Collections.emptyMap();
 
         tracks.add(new YoutubeTrackFormat(
             ContentType.parse(formatJson.safeGet("mimeType").text()),
             formatJson.safeGet("bitrate").as(Long.class),
             formatJson.safeGet("contentLength").as(Long.class),
-            cipherInfo.get("url"),
+            cipherInfo.getOrDefault("url", formatJson.get("url").text()),
             cipherInfo.get("s"),
-            cipherInfo.get("sp")
+            cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
         ));
       }
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.StringJoiner;


### PR DESCRIPTION
Fixes in this PR:
- Formats with no cipher, thus have no `cipher` property (NullPointerException)
- Videos that are unavailable/copyrighted/deleted but Lavaplayer wasn't aware due to not checking the status in `player_response` JSON (NullPointerException, and in some cases, `No formats`(?) error that was caused by videos that are not available in the region that Lavaplayer is being used in (geo-restricted).
- Checking `playabilityStatus` in `player_response` to determine whether a video is playable. (`IllegalStateException: Get only works on a map`)

