### PR TITLE
Fix SoundCloud direct URL playback

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
@@ -321,7 +321,7 @@ public class SoundCloudAudioSourceManager implements AudioSourceManager, HttpCon
       }
 
       String html = IOUtils.toString(response.getEntity().getContent(), Charset.forName(CHARSET));
-      String configJson = DataFormatTools.extractBetween(html, "e}var c=", ",o=Date.now()");
+      String configJson = DataFormatTools.extractBetween(html, "e}var c=", ",r=Date.now()");
 
       if (configJson == null) {
         throw new FriendlyException("This url does not appear to be a playable track.", SUSPICIOUS, null);


### PR DESCRIPTION
Loading tracks via direct URL (e.g. <https://soundcloud.com/itsrudeboy/love-sorrow>) throw `com.sedmelluq.discord.lavaplayer.tools.FriendlyException: This url does not appear to be a playable track.` 