### PR TITLE
Don't fail when given YT format without contentLength

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioTrack.java
@@ -218,14 +218,22 @@ public class YoutubeAudioTrack extends DelegatedAudioTrack {
             ? decodeUrlEncodedItems(cipher, true)
             : Collections.emptyMap();
 
-        tracks.add(new YoutubeTrackFormat(
-            ContentType.parse(formatJson.safeGet("mimeType").text()),
-            formatJson.safeGet("bitrate").as(Long.class),
-            formatJson.safeGet("contentLength").as(Long.class),
-            cipherInfo.getOrDefault("url", formatJson.get("url").text()),
-            cipherInfo.get("s"),
-            cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
-        ));
+        try {
+          JsonBrowser contentLength = formatJson.safeGet("contentLength");
+
+          if (contentLength == null) continue;
+
+          tracks.add(new YoutubeTrackFormat(
+                  ContentType.parse(formatJson.safeGet("mimeType").text()),
+                  formatJson.safeGet("bitrate").as(Long.class),
+                  contentLength.as(Long.class),
+                  cipherInfo.getOrDefault("url", formatJson.get("url").text()),
+                  cipherInfo.get("s"),
+                  cipherInfo.getOrDefault("sp", DEFAULT_SIGNATURE_KEY)
+          ));
+        } catch(RuntimeException e) {
+          log.debug("Failed to parse format {}", formatJson, e);
+        }
       }
     }
 


### PR DESCRIPTION
Prevents NPEs from happening when attempting to play certain YouTube tracks.

Example: https://www.youtube.com/watch?v=hDMtLbMSp0w

Not completely tested because Gradle is being a PITA. Also not very elegant either.
