### PR TITLE
Ipv6 balancing – Route requests from many different IPv6s

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeAudioSourceManager.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.*;
+import com.sedmelluq.discord.lavaplayer.tools.http.BalancingIpv6RoutePlanner;
 import com.sedmelluq.discord.lavaplayer.tools.http.HttpRequestModifier;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpConfigurable;
@@ -31,10 +32,9 @@ import org.apache.http.NameValuePair;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.utils.URIBuilder;
+import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
 import org.jsoup.Jsoup;
@@ -80,7 +80,6 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
   private final YoutubeMixProvider mixProvider;
   private final boolean allowSearch;
   private volatile int playlistPageCount;
-  private final Ipv6Block ipv6Block;
 
   /**
    * Create an instance with default settings.
@@ -100,15 +99,23 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
   /**
    * Create an instance.
    * @param allowSearch Whether to allow search queries as identifiers
-   * @param ipv6Block An IPv6 subnet to balance requests over
+   * @param routePlanner An IPv6 subnet to balance requests over
    */
-  public YoutubeAudioSourceManager(boolean allowSearch, Ipv6Block ipv6Block) {
+  public YoutubeAudioSourceManager(boolean allowSearch, HttpRoutePlanner routePlanner) {
     signatureCipherManager = new YoutubeSignatureCipherManager();
 
-    httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager(this::beforeRequest);
+    HttpRequestModifier requestModifier = request -> {
+      request.setHeader("x-youtube-client-name", "1");
+      request.setHeader("x-youtube-client-version", "2.20191008.04.01");
+    };
+
+    if (routePlanner == null) {
+      httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager(requestModifier);
+    } else {
+      httpInterfaceManager = HttpClientTools.createDefaultThreadLocalManager(requestModifier, routePlanner);
+    }
 
     this.allowSearch = allowSearch;
-    this.ipv6Block = ipv6Block;
     playlistPageCount = 6;
     searchProvider = new YoutubeSearchProvider(this);
     mixProvider = new YoutubeMixProvider(this);
@@ -535,26 +542,6 @@ public class YoutubeAudioSourceManager implements AudioSourceManager, HttpConfig
    */
   public YoutubeAudioTrack buildTrackObject(String videoId, String title, String uploader, boolean isStream, long duration) {
     return new YoutubeAudioTrack(new AudioTrackInfo(title, uploader, duration, videoId, isStream, getWatchUrl(videoId)), this);
-  }
-
-  private void beforeRequest(HttpUriRequest request) {
-    request.setHeader("x-youtube-client-name", "1");
-    request.setHeader("x-youtube-client-version", "2.20191008.04.01");
-
-    if (ipv6Block != null && request instanceof HttpRequestBase) {
-      HttpRequestBase hrb = (HttpRequestBase) request;
-
-      // Skip if a local address is already explicitly configured
-      if (hrb.getConfig() != null && hrb.getConfig().getLocalAddress() != null) return;
-
-      RequestConfig.Builder builder = hrb.getConfig() == null
-          ? RequestConfig.custom()
-          : RequestConfig.copy(hrb.getConfig());
-
-      hrb.setConfig(
-          builder.setLocalAddress(ipv6Block.getRandomSlash64()).build()
-      );
-    }
   }
 
   private static String getWatchUrl(String videoId) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Block.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Block.java
@@ -41,8 +41,8 @@ public class Ipv6Block {
     }
     maskBits = Integer.parseInt(matcher.group(2));
 
-    if (maskBits > TRUNCATED_BITS - 1 || maskBits < 1) {
-      throw new IllegalArgumentException("This class only handles /1-63 subnets. Got /" + maskBits);
+    if (maskBits > TRUNCATED_BITS || maskBits < 1) {
+      throw new IllegalArgumentException("This class only handles /1-64 subnets. Got /" + maskBits);
     }
 
     // Truncate all bits after $maskBits$ number of bits in the prefix
@@ -57,6 +57,9 @@ public class Ipv6Block {
    * @return a random /64 member subnet of this subnet.
    */
   public Inet6Address getRandomSlash64() {
+    // /64 blocks acts as a singleton
+    if (maskBits == 64) return longToAddress(prefix);
+
     // Create a mask of variable length to be AND'ed with a random value
     long randMask = Long.MAX_VALUE >> maskBits - 1;
     long maskedRandom = random.nextLong() & randMask;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Block.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Block.java
@@ -11,7 +11,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
- * @author Fre_d
+ * @author Frederik Arbjerg Mikkelsen
  */
 public class Ipv6Block {
 
@@ -46,6 +46,7 @@ public class Ipv6Block {
     }
 
     // Truncate all bits after $maskBits$ number of bits in the prefix
+    //noinspection ShiftOutOfRange
     long prefixMask = Long.MAX_VALUE << (IPV6_BIT_SIZE - maskBits - 1);
     prefix = unboundedPrefix & prefixMask;
 
@@ -55,13 +56,13 @@ public class Ipv6Block {
   /**
    * @return a random /64 member subnet of this subnet.
    */
-  public InetAddress getRandomSlash64() {
+  public Inet6Address getRandomSlash64() {
     // Create a mask of variable length to be AND'ed with a random value
     long randMask = Long.MAX_VALUE >> maskBits - 1;
     long maskedRandom = random.nextLong() & randMask;
 
     // Combine prefix and match
-    InetAddress inetAddress = longToAddress(prefix + maskedRandom);
+    Inet6Address inetAddress = longToAddress(prefix + maskedRandom);
     //log.info(Long.toBinaryString(prefix + maskedRandom));
     log.info(inetAddress.toString());
     //log.info("\nPref:{}\nMask:{}\nRand:{}\nRslt:{}", Long.toBinaryString(prefix), Long.toBinaryString(randMask), Long.toBinaryString(maskedRandom), Long.toBinaryString(prefix + maskedRandom));
@@ -73,7 +74,7 @@ public class Ipv6Block {
     return cidr;
   }
 
-  private static InetAddress longToAddress(long l) {
+  private static Inet6Address longToAddress(long l) {
     byte[] b = new byte[]{
         (byte) (l >> 56),
         (byte) (l >> 48),
@@ -88,7 +89,7 @@ public class Ipv6Block {
     };
 
     try {
-      return Inet6Address.getByAddress(b);
+      return (Inet6Address) Inet6Address.getByAddress(b);
     } catch (UnknownHostException e) {
       throw new RuntimeException(e); // This should not happen, as we do not do a DNS lookup
     }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
@@ -1,0 +1,71 @@
+package com.sedmelluq.discord.lavaplayer.tools;
+
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * @author Fre_d
+ */
+public class Ipv6Subnet {
+
+  private final Pattern cidrRegex = Pattern.compile("([\\da-f:]+)/(\\d{1,3})");
+  private final String cidr;
+  private final int maskBits; // 1-128
+  private final long prefix;
+
+  public Ipv6Subnet(String cidr) {
+    this.cidr = cidr.toLowerCase();
+    Matcher matcher = cidrRegex.matcher(this.cidr);
+    if (!matcher.find()) {
+      throw new IllegalArgumentException(cidr + " does not appear to be a valid CIDR.");
+    }
+
+    try {
+      InetAddress byName = InetAddress.getByName(matcher.group(1));
+      prefix = addressToLong((Inet6Address) byName);
+    } catch (UnknownHostException e) {
+      throw new IllegalArgumentException("Invalid IPv6 address", e);
+    }
+    maskBits = Integer.parseInt(matcher.group(2));
+  }
+
+  private static InetAddress longToAddress(long l) {
+    byte[] b = new byte[] {
+        (byte) l,
+        (byte) (l >> 8),
+        (byte) (l >> 16),
+        (byte) (l >> 24),
+        (byte) (l >> 32),
+        (byte) (l >> 40),
+        (byte) (l >> 48),
+        (byte) (l >> 56),
+        0, 0, 0, 0,
+        0, 0, 0, 0
+    };
+
+    try {
+      return Inet6Address.getByAddress(b);
+    } catch (UnknownHostException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * The last 64 bits are truncated
+   */
+  private static long addressToLong(Inet6Address address) {
+    byte[] b = address.getAddress();
+    return ((long) b[7] << 56)
+        | ((long) b[6] & 0xff) << 48
+        | ((long) b[5] & 0xff) << 40
+        | ((long) b[4] & 0xff) << 32
+        | ((long) b[3] & 0xff) << 24
+        | ((long) b[2] & 0xff) << 16
+        | ((long) b[1] & 0xff) << 8
+        | ((long) b[0] & 0xff);
+  }
+
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
@@ -3,6 +3,7 @@ package com.sedmelluq.discord.lavaplayer.tools;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.Random;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -11,33 +12,61 @@ import java.util.regex.Pattern;
  */
 public class Ipv6Subnet {
 
-  private final Pattern cidrRegex = Pattern.compile("([\\da-f:]+)/(\\d{1,3})");
+  private static final int IPV6_BIT_SIZE = 128;
+  private static final int TRUNCATED_BITS = 64;
+  private static final Random random = new Random();
+
+  private static final Pattern CIDR_REGEX = Pattern.compile("([\\da-f:]+)/(\\d{1,3})");
   private final String cidr;
   private final int maskBits; // 1-128
   private final long prefix;
 
   public Ipv6Subnet(String cidr) {
     this.cidr = cidr.toLowerCase();
-    Matcher matcher = cidrRegex.matcher(this.cidr);
+    Matcher matcher = CIDR_REGEX.matcher(this.cidr);
     if (!matcher.find()) {
       throw new IllegalArgumentException(cidr + " does not appear to be a valid CIDR.");
     }
 
+    long unboundedPrefix;
     try {
-      InetAddress byName = InetAddress.getByName(matcher.group(1));
-      prefix = addressToLong((Inet6Address) byName);
+      InetAddress address = InetAddress.getByName(matcher.group(1));
+      unboundedPrefix = addressToLong((Inet6Address) address);
     } catch (UnknownHostException e) {
       throw new IllegalArgumentException("Invalid IPv6 address", e);
     }
     maskBits = Integer.parseInt(matcher.group(2));
 
-    if (maskBits > 64 || maskBits < 1) {
-      throw new IllegalArgumentException("This class only handles with /1-64 subnets. Got /" + maskBits);
+    if (maskBits > TRUNCATED_BITS || maskBits < 1) {
+      throw new IllegalArgumentException("This class only handles /1-64 subnets. Got /" + maskBits);
     }
+
+    // Truncate all bits after $maskBits$ number of bits in the prefix
+    @SuppressWarnings("ShiftOutOfRange")
+    long prefixMask = Long.MAX_VALUE << (IPV6_BIT_SIZE - maskBits);
+    prefix = unboundedPrefix & prefixMask;
+  }
+
+  /**
+   * @return a random /64 member subnet of this subnet.
+   */
+  public InetAddress getRandomSlash64() {
+    // Create a mask of variable length to be AND'ed with a random value
+    int prefixBits = IPV6_BIT_SIZE - maskBits;
+    long randMask = Long.MAX_VALUE >> prefixBits;
+    long maskedRandom = random.nextLong() & randMask;
+
+    // Combine prefix and match
+    return longToAddress(prefix | maskedRandom);
+  }
+
+  @Override
+  public String toString() {
+    return cidr;
   }
 
   private static InetAddress longToAddress(long l) {
-    byte[] b = new byte[] {
+    byte[] b = new byte[]{
         (byte) l,
         (byte) (l >> 8),
         (byte) (l >> 16),
@@ -53,7 +82,7 @@ public class Ipv6Subnet {
     try {
       return Inet6Address.getByAddress(b);
     } catch (UnknownHostException e) {
-      throw new RuntimeException(e);
+      throw new RuntimeException(e); // This should not happen, as we do not do a DNS lookup
     }
   }
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/Ipv6Subnet.java
@@ -30,6 +30,10 @@ public class Ipv6Subnet {
       throw new IllegalArgumentException("Invalid IPv6 address", e);
     }
     maskBits = Integer.parseInt(matcher.group(2));
+
+    if (maskBits > 64 || maskBits < 1) {
+      throw new IllegalArgumentException("This class only handles with /1-64 subnets. Got /" + maskBits);
+    }
   }
 
   private static InetAddress longToAddress(long l) {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
@@ -84,7 +84,7 @@ public class BalancingIpv6RoutePlanner implements HttpRoutePlanner {
       remoteAddress = ip4;
       log.warn("Could not look up AAAA record for {}. Falling back to unbalanced IPv4.", host.getHostName());
     } else {
-      throw new HttpException("Could not resolve " + host.getHostName();
+      throw new HttpException("Could not resolve " + host.getHostName());
     }
 
     HttpHost target = new HttpHost(remoteAddress, host.getHostName(), remotePort, host.getSchemeName());

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
@@ -1,0 +1,89 @@
+package com.sedmelluq.discord.lavaplayer.tools.http;
+
+import com.sedmelluq.discord.lavaplayer.tools.Ipv6Block;
+import org.apache.http.HttpException;
+import org.apache.http.HttpHost;
+import org.apache.http.HttpRequest;
+import org.apache.http.ProtocolException;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
+import org.apache.http.conn.SchemePortResolver;
+import org.apache.http.conn.UnsupportedSchemeException;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.conn.routing.HttpRoutePlanner;
+import org.apache.http.impl.conn.DefaultSchemePortResolver;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.util.Args;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.Inet4Address;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+public class BalancingIpv6RoutePlanner implements HttpRoutePlanner {
+
+  private static final Logger log = LoggerFactory.getLogger(BalancingIpv6RoutePlanner.class);
+  private final Ipv6Block ipBlock;
+  private final SchemePortResolver schemePortResolver;
+
+  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock) {
+    this(ipBlock, DefaultSchemePortResolver.INSTANCE);
+  }
+
+  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock, SchemePortResolver schemePortResolver) {
+    this.ipBlock = ipBlock;
+    this.schemePortResolver = schemePortResolver;
+  }
+
+  @Override
+  public HttpRoute determineRoute(HttpHost host, HttpRequest request, HttpContext context) throws HttpException {
+    Args.notNull(request, "Request");
+    if (host == null) {
+      throw new ProtocolException("Target host is not specified");
+    }
+    final HttpClientContext clientContext = HttpClientContext.adapt(context);
+    final RequestConfig config = clientContext.getRequestConfig();
+    int remotePort;
+    if (host.getPort() <= 0) {
+      try {
+        remotePort = schemePortResolver.resolve(host);
+      } catch (UnsupportedSchemeException e) {
+        throw new HttpException(e.getMessage());
+      }
+    } else remotePort = host.getPort();
+
+    Stream<InetAddress> ipStream;
+    try {
+      ipStream = Arrays.stream(InetAddress.getAllByName(host.getHostName()));
+    } catch (UnknownHostException e) {
+      throw new HttpException("Could not resolve " + host.getHostName(), e);
+    }
+
+    InetAddress remoteAddress;
+    InetAddress localAddress;
+    Optional<InetAddress> ip6 = ipStream.filter(Inet6Address.class::isInstance).findAny();
+    if (ip6.isPresent()) {
+      localAddress = ipBlock.getRandomSlash64();
+      remoteAddress = ip6.get();
+    } else {
+      Optional<InetAddress> ip4 = ipStream.filter(Inet4Address.class::isInstance).findAny();
+      localAddress = null;
+      remoteAddress = ip4.orElseThrow(() -> new HttpException("Could not resolve " + host.getHostName()));
+      log.warn("Could not look up AAAA record for {}. Falling back to unbalanced IPv4.", host.getHostName());
+    }
+
+    HttpHost target = new HttpHost(remoteAddress, host.getHostName(), remotePort, host.getSchemeName());
+    HttpHost proxy = config.getProxy();
+    final boolean secure = target.getSchemeName().equalsIgnoreCase("https");
+    if (proxy == null) {
+      return new HttpRoute(target, localAddress, secure);
+    } else {
+      return new HttpRoute(target, localAddress, proxy, secure);
+    }
+  }
+}

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/http/BalancingIpv6RoutePlanner.java
@@ -48,7 +48,7 @@ public class BalancingIpv6RoutePlanner implements HttpRoutePlanner {
    * @param ipBlock the block to perform balancing over.
    * @param ipFilter function to filter out certain IP addresses picked from the IP block, causing another random to be chosen.
    */
-  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock, Predicate<InetAddress> ipFilter) {
+  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock, Predicate<Inet6Address> ipFilter) {
     this(ipBlock, ipFilter, DefaultSchemePortResolver.INSTANCE);
   }
 
@@ -57,7 +57,7 @@ public class BalancingIpv6RoutePlanner implements HttpRoutePlanner {
    * @param ipFilter function to filter out certain IP addresses picked from the IP block, causing another random to be chosen.
    * @param schemePortResolver for resolving ports for schemes where the port is not explicitly stated.
    */
-  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock, Predicate<InetAddress> ipFilter, SchemePortResolver schemePortResolver) {
+  public BalancingIpv6RoutePlanner(Ipv6Block ipBlock, Predicate<Inet6Address> ipFilter, SchemePortResolver schemePortResolver) {
     this.ipBlock = ipBlock;
     this.ipFilter = ipFilter;
     this.schemePortResolver = schemePortResolver;
@@ -88,7 +88,7 @@ public class BalancingIpv6RoutePlanner implements HttpRoutePlanner {
     }
 
     InetAddress remoteAddress;
-    InetAddress localAddress;
+    Inet6Address localAddress;
     Inet6Address ip6 = null;
     Inet4Address ip4 = null;
 

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/HttpClientTools.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/tools/io/HttpClientTools.java
@@ -23,6 +23,7 @@ import org.apache.http.config.MessageConstraints;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.socket.PlainConnectionSocketFactory;
 import org.apache.http.conn.ssl.DefaultHostnameVerifier;
@@ -99,6 +100,17 @@ public class HttpClientTools {
   public static HttpInterfaceManager createDefaultThreadLocalManager(HttpRequestModifier requestModifier) {
     return new ThreadLocalHttpInterfaceManager(createSharedCookiesHttpBuilder(), DEFAULT_REQUEST_CONFIG,
         requestModifier);
+  }
+
+  /**
+   * @return Default HTTP interface manager with a custom HttpRoutePlanner and thread-local context
+   */
+  public static HttpInterfaceManager createDefaultThreadLocalManager(HttpRequestModifier requestModifier, HttpRoutePlanner routePlanner) {
+    return new ThreadLocalHttpInterfaceManager(
+        createSharedCookiesHttpBuilder().setRoutePlanner(routePlanner),
+        DEFAULT_REQUEST_CONFIG,
+        requestModifier
+    );
   }
 
   /**


### PR DESCRIPTION
This PR allows setting a contiguous IPv6 block larger than a /64 for use with YouTube. This gets around those pesky 429s.

### Changelist
* Added a way to set a custom route planner in the the YouTube source manager.
* Added an optional `HttpRoutePlanner` implementation which uses random IPv6.
* The new route planner falls back to IPv4 with a warning.
* Added a util class to pick random IPv6 addresses.

This has not been used in production yet.

A Lavalink build (with certain other PRs included) is also available:
https://github.com/Frederikam/Lavalink/tree/experimental/429-fix