### PR TITLE
Fix finding SoundCloud asset script

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java
@@ -232,27 +232,21 @@ public class SoundCloudAudioSourceManager implements AudioSourceManager, HttpCon
 
       String page = EntityUtils.toString(response.getEntity());
       Matcher scriptMatcher = pageAppScriptPattern.matcher(page);
-      MatchResult result = getMatchIndex(scriptMatcher, 7);
+      String result = getLastMatchWithinLimit(scriptMatcher, 7);
 
       if (result != null) {
-        return result.group(0);
+        return result;
       } else {
         throw new IllegalStateException("Could not find application script from main page.");
       }
     }
   }
 
-  private MatchResult getMatchIndex(Matcher m, int index) {
-    int currentIndex = 0;
-
-    while (currentIndex < index) {
-      if (!m.find()) {
-        return null;
-      }
-      currentIndex++;
-    }
-
-    return m.toMatchResult();
+  private String getLastMatchWithinLimit(Matcher m, int limit) {
+    String lastMatch = null;
+    for(int i = 0; m.find() && i < limit; ++i)
+        lastMatch = m.group();
+    return lastMatch;
   }
 
   private String findClientIdFromApplicationScript(HttpInterface httpInterface, String scriptUrl) throws IOException {


### PR DESCRIPTION
When I was running the latest version as of this PR (`1.3.22.pbjtest3`), I was hitting this issue:
```
[04:36:34] [INFO] [SoundCloudAudioSourceManager]: Updating SoundCloud client ID (current is ...).
[04:36:35] [ERROR] [SoundCloudAudioSourceManager]: SoundCloud client ID update failed.
java.lang.IllegalStateException: Could not find application script from main page.
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.findApplicationScriptUrl(SoundCloudAudioSourceManager.java:238)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.findClientIdFromSite(SoundCloudAudioSourceManager.java:220)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.updateClientId(SoundCloudAudioSourceManager.java:198)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.withClientIdRetry(SoundCloudAudioSourceManager.java:584)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.loadSearchResult(SoundCloudAudioSourceManager.java:540)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.processAsSearchQuery(SoundCloudAudioSourceManager.java:523)
	at com.sedmelluq.discord.lavaplayer.source.soundcloud.SoundCloudAudioSourceManager.loadItem(SoundCloudAudioSourceManager.java:126)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItemOnce(DefaultAudioPlayerManager.java:437)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.checkSourcesForItem(DefaultAudioPlayerManager.java:419)
	at com.sedmelluq.discord.lavaplayer.player.DefaultAudioPlayerManager.lambda$createItemLoader$0(DefaultAudioPlayerManager.java:218)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at com.sedmelluq.discord.lavaplayer.tools.OrderedExecutor$ChannelRunnable.executeQueue(OrderedExecutor.java:98)
	at com.sedmelluq.discord.lavaplayer.tools.OrderedExecutor$ChannelRunnable.run(OrderedExecutor.java:87)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```
After some digging, I found that the problem was that lavaplayer was [attempting to use the 7th script on the page to update the client ID](https://github.com/sedmelluq/lavaplayer/blob/master/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudAudioSourceManager.java#L235), but there were only 6 scripts that matched the regex on the page. After [some discussion on Discord](https://discordapp.com/channels/125227483518861312/263484072389640193/637723748635639888), it seemed as if some locations were getting 6 scripts and others were getting 7. 

Doing some manual requests from different locations confirmed this:
https://hastebin.com/coduduvije.html
https://hastebin.com/tusuzeyogo.html
Diff: https://www.diffchecker.com/1jkh0a9D

Line 158 of the diff suggests that some locations or clients get an extra script on the page. This PR solves this by using the 7th script, unless fewer than 7 exist, in which case it attempts to use the last script. I've tested this on a bot that was having this issue, and this solved the problem.