### PR TITLE
Use HTTPS for JCenter url

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Using in Maven:
   <repository>
     <id>central</id>
     <name>bintray</name>
-    <url>http://jcenter.bintray.com</url>
+    <url>https://jcenter.bintray.com</url>
   </repository>
 </repositories>
 


### PR DESCRIPTION
JCenter will soon not support HTTP anymore: https://jfrog.com/blog/secure-jcenter-with-https/