### PR TITLE
IPv4 rotation fix

### DIFF
--- a/extensions/youtube-rotator/src/main/java/com/sedmelluq/lava/extensions/youtuberotator/planner/RotatingIpRoutePlanner.java
+++ b/extensions/youtube-rotator/src/main/java/com/sedmelluq/lava/extensions/youtuberotator/planner/RotatingIpRoutePlanner.java
@@ -109,7 +109,7 @@ public final class RotatingIpRoutePlanner extends AbstractRoutePlanner {
     }
 
     if (currentAddress == null && index.get().compareTo(BigInteger.ZERO) > 0)
-      currentAddress = ipBlock.getAddressAtIndex(index.get().subtract(BigInteger.ONE));
+      currentAddress = ipBlock.getAddressAtIndex(index.get());
     next.set(false);
     return new Tuple<>(currentAddress, remoteAddress);
   }
@@ -143,7 +143,7 @@ public final class RotatingIpRoutePlanner extends AbstractRoutePlanner {
         rotateIndex.accumulateAndGet(Ipv6Block.BLOCK64_IPS.add(BigInteger.valueOf(random.nextLong())), BigInteger::add);
       }
       try {
-        localAddress = ipBlock.getAddressAtIndex(index.get().subtract(BigInteger.ONE));
+        localAddress = ipBlock.getAddressAtIndex(index.get());
       } catch (final Exception ex) {
         index.set(BigInteger.ZERO);
         localAddress = null;


### PR DESCRIPTION
## Problem
IPv4 rotation is currently broken. When the route planner tries to find a new Ip it would always pass in a 0 to the `getAddressAtIndex` on the ipblock. This would always return an exception (it checks if the index is 0 or lower and throws)

## Solution
Remove the code in the route planner that subtracts one from the block index. This fix works for me currently using either 1 large ipv4 block, or a list of ipv4 /32 blocks. I cannot test this fix on any of the ipv6 rotation stuff. 
As I am not too familiar with the code base, would this fix be better to implement on the rotator level or within the IP block? I currently changed it within the rotator as that is how my current custom implementation does it and I am not sure if changing it on the IP block level would possibly introduce some regressions.

I am happy to change this fix based on any comments/suggestions.