### PR TITLE
Prefer mp3 over ogg

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudFormatHandler.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudFormatHandler.java
@@ -6,13 +6,13 @@ public class DefaultSoundCloudFormatHandler implements SoundCloudFormatHandler {
   @Override
   public SoundCloudTrackFormat chooseBestFormat(List<SoundCloudTrackFormat> formats) {
     for (SoundCloudTrackFormat format : formats) {
-      if ("hls".equals(format.getProtocol()) && format.getMimeType().contains("audio/ogg")) {
+      if ("progressive".equals(format.getProtocol()) && format.getMimeType().contains("audio/mpeg")) {
         return format;
       }
     }
 
     for (SoundCloudTrackFormat format : formats) {
-      if ("progressive".equals(format.getProtocol()) && format.getMimeType().contains("audio/mpeg")) {
+      if ("hls".equals(format.getProtocol()) && format.getMimeType().contains("audio/ogg")) {
         return format;
       }
     }


### PR DESCRIPTION
This PR changes the DefaultSoundCloudFormatHandler to prefer mpeg over ogg.
The reason for this is because there are a few bots out there which seem to be suffering from "The track is stuck and is unable to resume" issue when playing `audio/ogg` formats from SoundCloud. I've only swapped the for loops as there could still be some usefulness in supporting ogg, however glitchy it might be.