### PR TITLE
[SoundCloud] Partition track IDs by 50 elements

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudPlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudPlaylistLoader.java
@@ -95,13 +95,19 @@ public class DefaultSoundCloudPlaylistLoader implements SoundCloudPlaylistLoader
         .map(dataReader::readTrackId)
         .collect(Collectors.toList());
 
-    List<JsonBrowser> trackDataList;
+    int numTrackIds = trackIds.size();
+    List<JsonBrowser> trackDataList = new ArrayList<>();
 
-    try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(buildTrackListUrl(trackIds)))) {
-      HttpClientTools.assertSuccessWithContent(response, "track list response");
+    for (int i = 0; i < numTrackIds; i += 50) {
+      int last = Math.min(i + 49, numTrackIds);
+      List<String> trackIdSegment = trackIds.subList(i, last);
 
-      JsonBrowser trackList = JsonBrowser.parse(response.getEntity().getContent());
-      trackDataList = trackList.values();
+      try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(buildTrackListUrl(trackIdSegment)))) {
+        HttpClientTools.assertSuccessWithContent(response, "track list response");
+
+        JsonBrowser trackList = JsonBrowser.parse(response.getEntity().getContent());
+        trackDataList.addAll(trackList.values());
+      }
     }
 
     sortPlaylistTracks(trackDataList, trackIds);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudPlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudPlaylistLoader.java
@@ -99,7 +99,7 @@ public class DefaultSoundCloudPlaylistLoader implements SoundCloudPlaylistLoader
     List<JsonBrowser> trackDataList = new ArrayList<>();
 
     for (int i = 0; i < numTrackIds; i += 50) {
-      int last = Math.min(i + 49, numTrackIds);
+      int last = Math.min(i + 50, numTrackIds);
       List<String> trackIdSegment = trackIds.subList(i, last);
 
       try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(buildTrackListUrl(trackIdSegment)))) {


### PR DESCRIPTION
This fixes an issue where trying to resolve more than 50 track IDs at once would cause SoundCloud to return `400: Bad Request`.

This has been tested with some of the erroneous URLs listed in #284, and all of them are now working.