### PR TITLE
Fix loading of YouTube livestreams, and add basic retry mechanism.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
@@ -79,7 +79,8 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
     if (playerResponse != null) {
       JsonBrowser playerData = JsonBrowser.parse(playerResponse);
       JsonBrowser streamingData = playerData.get("streamingData");
-      boolean isLive = playerData.get("videoDetails").get("isLive").as(Boolean.class);
+      JsonBrowser isLiveNode = playerData.get("videoDetails").get("isLive");
+      boolean isLive = isLiveNode.isNull() ? false : isLiveNode.as(Boolean.class);
 
       if (!streamingData.isNull()) {
         List<YoutubeTrackFormat> formats = loadTrackFormatsFromStreamingData(streamingData.get("formats"), isLive);


### PR DESCRIPTION
- Removes contentLength check for livestreams. This should default to itag 140 (`audio/mp4`).
- Adds a basic retry mechanism to `YoutubeMpegStreamAudioTrack`. When it requests the next segment, if it receives a 204 or the content length is 0, it will wait 400ms before requesting again.
  - This is basic in the sense that it will only retry once before giving up and marking the stream as finished.

A delay of 400ms *should* be fine. I tested this with 250ms delay originally and the stream lasted for 24 minutes before finishing. There is no jitter/audible choppiness with a 400ms delay.