### PR TITLE
Opt missing lengthSeconds for livestreams in playlists.

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -2,6 +2,7 @@ package com.sedmelluq.discord.lavaplayer.source.youtube;
 
 import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
+import com.sedmelluq.discord.lavaplayer.tools.Units;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import com.sedmelluq.discord.lavaplayer.track.AudioPlaylist;
@@ -142,7 +143,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
         String videoId = item.get("videoId").text();
         String title = item.get("title").get("simpleText").text();
         String author = shortBylineText.get("runs").index(0).get("text").text();
-        long duration = Long.parseLong(item.get("lengthSeconds").text()) * 1000;
+        long duration = item.get("lengthSeconds").asLong(Units.DURATION_SEC_UNKNOWN) * 1000;
 
         AudioTrackInfo info = new AudioTrackInfo(title, author, duration, videoId, false,
             "https://www.youtube.com/watch?v=" + videoId);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -143,7 +143,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
         String videoId = item.get("videoId").text();
         String title = item.get("title").get("simpleText").text();
         String author = shortBylineText.get("runs").index(0).get("text").text();
-        long duration = item.get("lengthSeconds").asLong(Units.DURATION_SEC_UNKNOWN) * 1000;
+        long duration = item.get("lengthSeconds").asLong(Units.SECONDS_MAXIMUM) * 1000;
 
         AudioTrackInfo info = new AudioTrackInfo(title, author, duration, videoId, false,
             "https://www.youtube.com/watch?v=" + videoId);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -143,7 +143,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
         String videoId = item.get("videoId").text();
         String title = item.get("title").get("simpleText").text();
         String author = shortBylineText.get("runs").index(0).get("text").text();
-        long duration = item.get("lengthSeconds").asLong(Units.SECONDS_MAXIMUM) * 1000;
+        JsonBrowser lengthSeconds = item.get("lengthSeconds");
+        long duration = lengthSeconds.isNull() ? Units.DURATION_MS_UNKNOWN : lengthSeconds.as(Long.class) * 1000;
 
         AudioTrackInfo info = new AudioTrackInfo(title, author, duration, videoId, false,
             "https://www.youtube.com/watch?v=" + videoId);

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -144,7 +144,7 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
         String title = item.get("title").get("simpleText").text();
         String author = shortBylineText.get("runs").index(0).get("text").text();
         JsonBrowser lengthSeconds = item.get("lengthSeconds");
-        long duration = lengthSeconds.isNull() ? Units.DURATION_MS_UNKNOWN : lengthSeconds.as(Long.class) * 1000;
+        long duration = Units.secondsToMillis(lengthSeconds.asLong(Units.DURATION_SEC_UNKNOWN));
 
         AudioTrackInfo info = new AudioTrackInfo(title, author, duration, videoId, false,
             "https://www.youtube.com/watch?v=" + videoId);


### PR DESCRIPTION
When loading a playlist that contains livestreams, Lavaplayer will try to fetch the `lengthSeconds` value, but being a livestream, this doesn't exist.

This PR pulls `DURATION_SEC_UNKNOWN` when `lengthSeconds` is not present.

Solution for #275.