### PR TITLE
Fix YT NullPointerException

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
@@ -179,6 +179,11 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
     if (!formats.isNull() && formats.isList()) {
       for (JsonBrowser formatJson : formats.values()) {
         String cipher = formatJson.get("cipher").text();
+
+        if (cipher == null) {
+          cipher = formatJson.get("signatureCipher").text();
+        }
+
         Map<String, String> cipherInfo = cipher != null
             ? decodeUrlEncodedItems(cipher, true)
             : Collections.emptyMap();


### PR DESCRIPTION
Check `signatureCipher` property if `cipher` is null.

Thanks to @Xavinlol for finding this.