### PR TITLE
Fix 401 on Twitch channel info req

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/twitch/TwitchStreamAudioSourceManager.java
@@ -75,12 +75,14 @@ public class TwitchStreamAudioSourceManager implements AudioSourceManager, HttpC
 
     JsonBrowser channelInfo = fetchStreamChannelInfo(streamName);
 
-    if (channelInfo == null) {
+    if (channelInfo == null || channelInfo.get("stream").isNull()) {
       return AudioReference.NO_TRACK;
     } else {
       //Use the stream name as the display name (we would require an additional call to the user to get the true display name)
       String displayName = streamName;
-      
+
+      /*
+      --- HELIX STUFF
       //Retrieve the data value list; this will have only one element since we're getting only one stream's information
       List<JsonBrowser> dataList = channelInfo.get("data").values();
     
@@ -92,6 +94,10 @@ public class TwitchStreamAudioSourceManager implements AudioSourceManager, HttpC
       //The first one has the title of the broadcast
       JsonBrowser channelData = dataList.get(0);
       String status = channelData.get("title").text();
+       */
+
+      JsonBrowser channelData = channelInfo.get("stream").get("channel");
+      String status = channelData.get("status").text();
 
       return new TwitchStreamAudioTrack(new AudioTrackInfo(
           status,
@@ -173,7 +179,8 @@ public class TwitchStreamAudioSourceManager implements AudioSourceManager, HttpC
 
   private JsonBrowser fetchStreamChannelInfo(String name) {
     try (HttpInterface httpInterface = getHttpInterface()) {
-      HttpUriRequest request = createGetRequest("https://api.twitch.tv/helix/streams?user_login=" + name);
+      // helix/streams?user_login=name
+      HttpUriRequest request = createGetRequest("https://api.twitch.tv/kraken/streams/" + name + "?stream_type=all");
 
       return HttpClientTools.fetchResponseAsJson(httpInterface, request);
     } catch (IOException e) {


### PR DESCRIPTION
- Make request to Kraken endpoint instead, which still works.

Apparently Kraken is supposed to be deprecated/removed soon, but while it still works it makes sense to use it. I did dive into Twitch's JS to figure out if there was any way to fetch an oauth token but my efforts were for nothing.

The alternative is perhaps scraping the title from the stream page itself.

This solution was mostly taken from `youtube-dl`, so if/when Twitch decide to kill off Kraken, we could perhaps look there for a solution.

This has been tested and confirmed working:
![](https://serux.pro/cdfa9ae95f.png)