### PR TITLE
Fix formatting when native load failed.

### DIFF
--- a/common/src/main/java/com/sedmelluq/lava/common/natives/NativeLibraryLoader.java
+++ b/common/src/main/java/com/sedmelluq/lava/common/natives/NativeLibraryLoader.java
@@ -85,7 +85,7 @@ public class NativeLibraryLoader {
       loadInternal();
       previousResult = true;
     } catch (Throwable e) {
-      log.error("Native library {}: loading failed.", e);
+      log.error("Native library {}: loading failed.", libraryName, e);
 
       previousFailure = new RuntimeException(e);
       previousResult = false;


### PR DESCRIPTION
Minor issue but fixes the `Native library {}: loading failed.` bad formatting.