### PR TITLE
Remove live streams from YT search result

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSearchProvider.java
@@ -158,6 +158,9 @@ public class YoutubeSearchProvider implements YoutubeSearchResultLoader {
 
     String title = json.get("title").get("runs").index(0).get("text").text();
     String author = json.get("ownerText").get("runs").index(0).get("text").text();
+    if (json.get("lengthText").isNull()) {
+      return null; // Ignore if the video is a live stream
+    }
     long duration = DataFormatTools.durationTextToMillis(json.get("lengthText").get("simpleText").text());
     String videoId = json.get("videoId").text();
 


### PR DESCRIPTION
Since 1.3.50, when search results contain [live stream](https://hastebin.com/homukicava.php) it passes `null` to `durationTextToMillis` and cause `NullPointerException`. This PR adds a simple check and removes live streams from search result.