### PR TITLE
Set ended live stream's isStream as false

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
@@ -308,7 +308,7 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
 
     JsonBrowser videoDetails = playerResponse.get("videoDetails");
 
-    boolean isStream = videoDetails.get("isLiveContent").asBoolean(false);
+    boolean isStream = "0".equals(videoDetails.get("lengthSeconds").text());
     long duration = extractDurationSeconds(isStream, videoDetails, "lengthSeconds");
 
     return buildTrackInfo(videoId, videoDetails.get("title").text(), videoDetails.get("author").text(), isStream, duration);


### PR DESCRIPTION
Current code checks if the video is a live stream by looking up for `isLiveContent` boolean, which youtube sets as `true` even if the live stream has ended, therefore it recognized ended live stream as live stream. This PR instead checks if the `duration` value is 0.

This will fix some WebM videos too, since non-live stream videos were flagged as live stream.

Example: https://www.youtube.com/watch?v=5x69RtE2hRA