### PR TITLE
Fix for Bandcamp album and track playback

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/bandcamp/BandcampAudioSourceManager.java
@@ -109,10 +109,13 @@ public class BandcampAudioSourceManager implements AudioSourceManager, HttpConfi
   }
 
   private String readBandUrl(String text) {
-    String bandUrl = DataFormatTools.extractBetween(text, "var band_url = \"", "\";");
+    String bandUrl = DataFormatTools.extractBetween(text, "linkback : \"", "\" + \"");
 
     if (bandUrl == null) {
-      throw new FriendlyException("Band information not found on the Bandcamp page.", SUSPICIOUS, null);
+      bandUrl = DataFormatTools.extractBetween(text, "linkback: \"", "\" + \"");
+      if (bandUrl == null) {
+        throw new FriendlyException("Band information not found on the Bandcamp page.", SUSPICIOUS, null);
+      }
     }
 
     return bandUrl;


### PR DESCRIPTION
Currently on lp 1.3.50 if you try to queue a Bandcamp track or album the "Band information not found on the Bandcamp page." friendly traceback is thrown as `band_url` is not found in the page response any more. This change corrects it to the `linkback` string instead. Unfortunately on album page sources this is styled as `linkback:` while on track pages it is `linkback :` with an extra space inbetween the word and the colon, so there is another line for checking the other linkback string condition.