### PR TITLE
[YT] Fix nullable track titles from a playlist

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -12,6 +12,7 @@ import com.sedmelluq.discord.lavaplayer.track.BasicAudioPlaylist;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.function.Function;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -141,7 +142,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
       // If the shortBylineText property does not exist, it means the Track is Region blocked
       if (!item.get("isPlayable").isNull() && !shortBylineText.isNull()) {
         String videoId = item.get("videoId").text();
-        String title = item.get("title").get("simpleText").text();
+        String title = Optional.ofNullable(item.get("title").get("simpleText").text())
+                .orElse(item.get("title").get("runs").index(0).get("text").text());
         String author = shortBylineText.get("runs").index(0).get("text").text();
         JsonBrowser lengthSeconds = item.get("lengthSeconds");
         long duration = Units.secondsToMillis(lengthSeconds.asLong(Units.DURATION_SEC_UNKNOWN));

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubePlaylistLoader.java
@@ -142,7 +142,8 @@ public class DefaultYoutubePlaylistLoader implements YoutubePlaylistLoader {
       // If the shortBylineText property does not exist, it means the Track is Region blocked
       if (!item.get("isPlayable").isNull() && !shortBylineText.isNull()) {
         String videoId = item.get("videoId").text();
-        String title = Optional.ofNullable(item.get("title").get("simpleText").text())
+        String title = Optional.ofNullable(item.get("title").get("simpleText"))
+                .map(JsonBrowser::text)
                 .orElse(item.get("title").get("runs").index(0).get("text").text());
         String author = shortBylineText.get("runs").index(0).get("text").text();
         JsonBrowser lengthSeconds = item.get("lengthSeconds");


### PR DESCRIPTION
When playing a playlist directly from youtube, it is getting the wrong key of title, as shown below:
Trying to get `simpleText`, but it doesn't exists.

![image](https://user-images.githubusercontent.com/32571975/96195260-ae269180-0f22-11eb-8737-8a873052fa63.png)

Since i didn't found any example of playlist that have a key `simpleText`, i decided to use Optional instead, to don't break scenarios that would have. If somebody knows that will never happens, so feel free to just remove that Optional and gets the `runs` key instead.

It fixes [#531](https://github.com/sedmelluq/lavaplayer/issues/531)