### PR TITLE
DefaultAudioPlayer: allow adding/removing of listeners during dispatchEvent

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayer.java
@@ -363,7 +363,8 @@ public class DefaultAudioPlayer implements AudioPlayer, TrackStateListener {
     log.debug("Firing an event with class {}", event.getClass().getSimpleName());
 
     synchronized (trackSwitchLock) {
-      for (AudioEventListener listener : listeners) {
+	  List<AudioEventListener> listenersCopy = new ArrayList<>(listeners);
+      for (AudioEventListener listener : listenersCopy) {
         try {
           listener.onEvent(event);
         } catch (Exception e) {


### PR DESCRIPTION
Iterates through a copy of the list so the original list can be free to be modified during iteration.

Closes #547 