### PR TITLE
Fix SoundCloud links not loading

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudHtmlDataLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/DefaultSoundCloudHtmlDataLoader.java
@@ -36,6 +36,6 @@ public class DefaultSoundCloudHtmlDataLoader implements SoundCloudHtmlDataLoader
   }
 
   protected String extractJsonFromHtml(String html) {
-    return DataFormatTools.extractBetween(html, "catch(t){}})},", ");</script>");
+    return DataFormatTools.extractBetween(html, "catch(e){}})},", ");</script>");
   }
 }


### PR DESCRIPTION
The string we were using to extract a json from the SoundCloud html was changed. Resolves #569