### PR TITLE
Allow for loading a track by AudioReference

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayerManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/AudioPlayerManager.java
@@ -4,6 +4,7 @@ import com.sedmelluq.discord.lavaplayer.remote.RemoteNodeRegistry;
 import com.sedmelluq.discord.lavaplayer.source.AudioSourceManager;
 import com.sedmelluq.discord.lavaplayer.tools.io.MessageInput;
 import com.sedmelluq.discord.lavaplayer.tools.io.MessageOutput;
+import com.sedmelluq.discord.lavaplayer.track.AudioReference;
 import com.sedmelluq.discord.lavaplayer.track.AudioTrack;
 import com.sedmelluq.discord.lavaplayer.track.DecodedTrackHolder;
 import java.io.IOException;
@@ -60,8 +61,22 @@ public interface AudioPlayerManager {
    * @param resultHandler A handler to process the result of this operation. It can either end by finding a track,
    *                      finding a playlist, finding nothing or terminating with an exception.
    * @return A future for this operation
+   * @see #loadItem(AudioReference, AudioLoadResultHandler)
    */
-  Future<Void> loadItem(final String identifier, final AudioLoadResultHandler resultHandler);
+  default Future<Void> loadItem(final String identifier, final AudioLoadResultHandler resultHandler) {
+    return loadItem(new AudioReference(identifier, null), resultHandler);
+  }
+
+  /**
+   * Schedules loading a track or playlist with the specified identifier.
+   * @param reference     The audio reference that holds the identifier that a specific source manager
+   *                      should be able to find the track with.
+   * @param resultHandler A handler to process the result of this operation. It can either end by finding a track,
+   *                      finding a playlist, finding nothing or terminating with an exception.
+   * @return A future for this operation
+   * @see #loadItem(String, AudioLoadResultHandler)
+   */
+  Future<Void> loadItem(final AudioReference reference, final AudioLoadResultHandler resultHandler);
 
   /**
    * Schedules loading a track or playlist with the specified identifier with an ordering key so that items with the
@@ -72,8 +87,25 @@ public interface AudioPlayerManager {
    * @param resultHandler A handler to process the result of this operation. It can either end by finding a track,
    *                      finding a playlist, finding nothing or terminating with an exception.
    * @return A future for this operation
+   * @see #loadItemOrdered(Object, AudioReference, AudioLoadResultHandler)
    */
-  Future<Void> loadItemOrdered(Object orderingKey, final String identifier, final AudioLoadResultHandler resultHandler);
+  default Future<Void> loadItemOrdered(Object orderingKey, final String identifier, final AudioLoadResultHandler resultHandler) {
+    return loadItemOrdered(orderingKey, new AudioReference(identifier, null), resultHandler);
+  }
+
+  /**
+   * Schedules loading a track or playlist with the specified identifier with an ordering key so that items with the
+   * same ordering key are handled sequentially in the order of calls to this method.
+   *
+   * @param orderingKey   Object to use as the key for the ordering channel
+   * @param reference     The audio reference that holds the identifier that a specific source manager
+   *                      should be able to find the track with.
+   * @param resultHandler A handler to process the result of this operation. It can either end by finding a track,
+   *                      finding a playlist, finding nothing or terminating with an exception.
+   * @return A future for this operation
+   * @see #loadItemOrdered(Object, String, AudioLoadResultHandler)
+   */
+  Future<Void> loadItemOrdered(Object orderingKey, final AudioReference reference, final AudioLoadResultHandler resultHandler);
 
   /**
    * Encode a track into an output stream. If the decoder is not supposed to know the number of tracks in advance, then

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/player/DefaultAudioPlayerManager.java
@@ -183,20 +183,20 @@ public class DefaultAudioPlayerManager implements AudioPlayerManager {
   }
 
   @Override
-  public Future<Void> loadItem(final String identifier, final AudioLoadResultHandler resultHandler) {
+  public Future<Void> loadItem(final AudioReference reference, final AudioLoadResultHandler resultHandler) {
     try {
-      return trackInfoExecutorService.submit(createItemLoader(identifier, resultHandler));
+      return trackInfoExecutorService.submit(createItemLoader(reference, resultHandler));
     } catch (RejectedExecutionException e) {
-      return handleLoadRejected(identifier, resultHandler, e);
+      return handleLoadRejected(reference.identifier, resultHandler, e);
     }
   }
 
   @Override
-  public Future<Void> loadItemOrdered(Object orderingKey, final String identifier, final AudioLoadResultHandler resultHandler) {
+  public Future<Void> loadItemOrdered(Object orderingKey, final AudioReference reference, final AudioLoadResultHandler resultHandler) {
     try {
-      return orderedInfoExecutor.submit(orderingKey, createItemLoader(identifier, resultHandler));
+      return orderedInfoExecutor.submit(orderingKey, createItemLoader(reference, resultHandler));
     } catch (RejectedExecutionException e) {
-      return handleLoadRejected(identifier, resultHandler, e);
+      return handleLoadRejected(reference.identifier, resultHandler, e);
     }
   }
 
@@ -209,20 +209,20 @@ public class DefaultAudioPlayerManager implements AudioPlayerManager {
     return ExecutorTools.COMPLETED_VOID;
   }
 
-  private Callable<Void> createItemLoader(final String identifier, final AudioLoadResultHandler resultHandler) {
+  private Callable<Void> createItemLoader(final AudioReference reference, final AudioLoadResultHandler resultHandler) {
     return () -> {
       boolean[] reported = new boolean[1];
 
       try {
-        if (!checkSourcesForItem(new AudioReference(identifier, null), resultHandler, reported)) {
-          log.debug("No matches for track with identifier {}.", identifier);
+        if (!checkSourcesForItem(reference, resultHandler, reported)) {
+          log.debug("No matches for track with identifier {}.", reference.identifier);
           resultHandler.noMatches();
         }
       } catch (Throwable throwable) {
         if (reported[0]) {
-          log.warn("Load result handler for {} threw an exception", identifier, throwable);
+          log.warn("Load result handler for {} threw an exception", reference.identifier, throwable);
         } else {
-          dispatchItemLoadFailure(identifier, resultHandler, throwable);
+          dispatchItemLoadFailure(reference.identifier, resultHandler, throwable);
         }
 
         ExceptionTools.rethrowErrors(throwable);


### PR DESCRIPTION
I created this feature because I want extra data into a custom audio source manager that I wrote, this seemed like the best way to implement it while staying backward compatible with older versions.
[My current solution][nice_hack] is a hacky workaround and this would make it much easier to just cast and have the data I need from a custom AudioReference class.

[nice_hack]: https://github.com/DuncteBot/SkyBot/blob/6baf9480d939dc4c53badec4d7aff15a093ab85d/src/main/java/ml/duncte123/skybot/audio/UserContextAudioPlayerManager.java