### PR TITLE
Fix 404 response on age restricted videos

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -202,7 +202,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     String videoApiUrl = "https://youtube.googleapis.com/v/" + videoId;
     String encodedApiUrl = URLEncoder.encode(videoApiUrl, UTF_8.name());
     String url = "https://www.youtube.com/get_video_info?video_id=" + videoId + "&eurl=" + encodedApiUrl +
-            "hl=en_GB";
+            "hl=en_GB&html5=1";
 
     if (sts != null) {
       url += "&sts=" + sts;


### PR DESCRIPTION
This YouTube endpoint now require `&html5=1` in request