### PR TITLE
Add retry system for expired Youtube ciphers (403)

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -6,8 +6,6 @@ import com.sedmelluq.discord.lavaplayer.tools.FriendlyException;
 import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
-import java.io.IOException;
-import java.net.URLEncoder;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -17,6 +15,9 @@ import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URLEncoder;
 
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeTrackJsonData.fromEmbedParts;
 import static com.sedmelluq.discord.lavaplayer.tools.ExceptionTools.throwWithDebugInfo;
@@ -297,13 +298,25 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     }
   }
 
-  protected static class CachedPlayerScript {
-    public final String playerScriptUrl;
-    public final long timestamp;
+  public CachedPlayerScript getCachedPlayerScript() {
+    return cachedPlayerScript;
+  }
+
+  public void clearCache() {
+    cachedPlayerScript = null;
+  }
+
+  public static class CachedPlayerScript {
+    private final String playerScriptUrl;
+    private final long timestamp;
 
     public CachedPlayerScript(String playerScriptUrl, long timestamp) {
       this.playerScriptUrl = playerScriptUrl;
       this.timestamp = timestamp;
+    }
+
+    public String getPlayerScriptUrl() {
+      return playerScriptUrl;
     }
   }
 }

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeSignatureCipherManager.java
@@ -2,6 +2,13 @@ package com.sedmelluq.discord.lavaplayer.source.youtube;
 
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.utils.URIBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -18,12 +25,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.io.IOUtils;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.client.utils.URIBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Handles parsing and caching of signature ciphers
@@ -233,6 +234,10 @@ public class YoutubeSignatureCipherManager implements YoutubeSignatureResolver {
     }
 
     return cipherKey;
+  }
+
+  public void clearCache(String cipherScriptUrl) {
+    cipherCache.remove(cipherScriptUrl);
   }
 
   private static String extractDollarEscapedFirstGroup(Pattern pattern, String text) {


### PR DESCRIPTION
Added a **temporary** (probably works, but not very scalable and good in terms of code design) solution for the 403 errors people have been getting due to the Youtube player scripts and cipher cache being outdated.
This has **not** been thoroughly tested and is my first time contributing to lavaplayer (well actually, my first time working with lavaplayer at all) so I apologize in advance for any mistakes with the code functionality or style.