### PR TITLE
Update regex for soundcloud application ID (#636)

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudClientIdTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudClientIdTracker.java
@@ -86,7 +86,7 @@ public class SoundCloudClientIdTracker {
 
       String page = EntityUtils.toString(response.getEntity());
       Matcher scriptMatcher = pageAppScriptPattern.matcher(page);
-      String result = getLastMatchWithinLimit(scriptMatcher, 7);
+      String result = getLastMatchWithinLimit(scriptMatcher, 10);
 
       if (result != null) {
         return result;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudClientIdTracker.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/soundcloud/SoundCloudClientIdTracker.java
@@ -20,7 +20,7 @@ public class SoundCloudClientIdTracker {
   private static final String ID_FETCH_CONTEXT_ATTRIBUTE = "sc-raw";
   private static final long CLIENT_ID_REFRESH_INTERVAL = TimeUnit.HOURS.toMillis(1);
   private static final String PAGE_APP_SCRIPT_REGEX = "https://[A-Za-z0-9-.]+/assets/[a-f0-9-]+\\.js";
-  private static final String APP_SCRIPT_CLIENT_ID_REGEX = ",client_id:\"([a-zA-Z0-9-_]+)\"";
+  private static final String APP_SCRIPT_CLIENT_ID_REGEX = "[^_]client_id:\"([a-zA-Z0-9-_]+)\"";
 
   private static final Pattern pageAppScriptPattern = Pattern.compile(PAGE_APP_SCRIPT_REGEX);
   private static final Pattern appScriptClientIdPattern = Pattern.compile(APP_SCRIPT_CLIENT_ID_REGEX);


### PR DESCRIPTION
It seems that soundcloud have updated their script so the current regex is no longer valid, since it looks for a comma where there is none:

```
{client_id:"t2YeOwu4P7hh0iGXpwrDt3g2QllKhBTq"}
```

This PR changes the regex to instead exclude underscores (so we don't match `apple_client_id` and `google_client_id` which are also present). Alternatively, we could probably match `[\{, ]` for a more restrictive approach.


Note: **This PR has not been tested whatsoever.** I just fiddled with the regex and was able to propose a potential fix, my hope is that the affected people can test.