### PR TITLE
Fixed 404 response on age restricted videos

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -214,7 +214,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     String videoApiUrl = "https://youtube.googleapis.com/v/" + videoId;
     String encodedApiUrl = URLEncoder.encode(videoApiUrl, UTF_8.name());
     String url = "https://www.youtube.com/get_video_info?video_id=" + videoId + "&eurl=" + encodedApiUrl +
-        "hl=en_GB&html5=1";
+        "&hl=en_GB&html5=1&c=ANDROID&cver=16.24";
 
     if (sts != null) {
       url += "&sts=" + sts;

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -40,8 +40,8 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     request.setHeader("user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
         "Chrome/76.0.3809.100 Safari/537.36");
-    request.setHeader("x-youtube-client-name", "1");
-    request.setHeader("x-youtube-client-version", "2.20191008.04.01");
+    request.setHeader("x-youtube-client-name", "ANDROID");
+    request.setHeader("x-youtube-client-version", "16.24");
     request.setHeader("x-youtube-page-cl", "276511266");
     request.setHeader("x-youtube-page-label", "youtube.ytfe.desktop_20191024_3_RC0");
     request.setHeader("x-youtube-utc-offset", "0");

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeHttpContextFilter.java
@@ -40,8 +40,8 @@ public class YoutubeHttpContextFilter extends BaseYoutubeHttpContextFilter {
 
     request.setHeader("user-agent", "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) " +
         "Chrome/76.0.3809.100 Safari/537.36");
-    request.setHeader("x-youtube-client-name", "ANDROID");
-    request.setHeader("x-youtube-client-version", "16.24");
+    request.setHeader("x-youtube-client-name", "1");
+    request.setHeader("x-youtube-client-version", "2.20191008.04.01");
     request.setHeader("x-youtube-page-cl", "276511266");
     request.setHeader("x-youtube-page-label", "youtube.ytfe.desktop_20191024_3_RC0");
     request.setHeader("x-youtube-utc-offset", "0");


### PR DESCRIPTION
Now this YouTube endpoint also require provide client and his version, using here `ANDROID` because in response we receive always deciphered links so it won't give 403 errors