### PR TITLE
Fix age restricted videos

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -7,19 +7,15 @@ import com.sedmelluq.discord.lavaplayer.tools.JsonBrowser;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpClientTools;
 import com.sedmelluq.discord.lavaplayer.tools.io.HttpInterface;
 import java.io.IOException;
-import java.net.URLEncoder;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
-import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeHttpContextFilter.PBJ_PARAMETER;
-import static com.sedmelluq.discord.lavaplayer.source.youtube.YoutubeTrackJsonData.fromEmbedParts;
 import static com.sedmelluq.discord.lavaplayer.tools.ExceptionTools.throwWithDebugInfo;
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.COMMON;
 import static com.sedmelluq.discord.lavaplayer.tools.FriendlyException.Severity.SUSPICIOUS;
@@ -30,13 +26,8 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
 
   private static final String AGE_VERIFY_REQUEST_URL = "https://www.youtube.com/youtubei/v1/verify_age?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
   private static final String AGE_VERIFY_REQUEST_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"WEB\",\"clientVersion\":\"2.20210302.07.01\"}},\"nextEndpoint\":{\"urlEndpoint\":{\"url\":\"%s\"}},\"setControvercy\":true}";
-
-  private static final String[] EMBED_CONFIG_PREFIXES = new String[]{
-      "'WEB_PLAYER_CONTEXT_CONFIGS':",
-      "WEB_PLAYER_CONTEXT_CONFIGS\":",
-      "'PLAYER_CONFIG':",
-      "\"PLAYER_CONFIG\":"
-  };
+  private static final String PLAYER_REQUEST_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
+  private static final String PLAYER_REQUEST_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"ANDROID\",\"clientVersion\":\"16.24\",\"clientScreen\":\"EMBED\"}},\"racyCheckOk\":true,\"contentCheckOk\":true,\"videoId\":\"%s\"}";
 
   private volatile CachedPlayerScript cachedPlayerScript = null;
 
@@ -91,12 +82,8 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     }
 
     if (requireFormats && status == InfoStatus.REQUIRES_LOGIN) {
-      JsonBrowser basicInfo = loadTrackBaseInfoFromEmbedPage(httpInterface, videoId);
-
-      return fromEmbedParts(
-          basicInfo,
-          loadTrackArgsFromVideoInfoPage(httpInterface, videoId, basicInfo.get("sts").text())
-      );
+      JsonBrowser trackInfo = loadTrackInfoFromInnertube(httpInterface, videoId);
+      return YoutubeTrackJsonData.fromMainResult(trackInfo);
     } else {
       return data;
     }
@@ -192,46 +179,24 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     }
   }
 
-  protected JsonBrowser loadTrackBaseInfoFromEmbedPage(HttpInterface httpInterface, String videoId) throws IOException {
-    try (CloseableHttpResponse response = httpInterface.execute(new HttpGet("https://www.youtube.com/embed/" + videoId))) {
-      HttpClientTools.assertSuccessWithContent(response, "embed video page response");
+  protected JsonBrowser loadTrackInfoFromInnertube(HttpInterface httpInterface, String videoId) throws IOException {
+    HttpPost post = new HttpPost(PLAYER_REQUEST_URL);
+    StringEntity payload = new StringEntity(String.format(PLAYER_REQUEST_PAYLOAD, videoId), "UTF-8");
+    post.setEntity(payload);
 
-      String html = EntityUtils.toString(response.getEntity(), UTF_8);
-      String configJson = DataFormatTools.extractAfter(html, EMBED_CONFIG_PREFIXES);
-
-      if (configJson != null) {
-        // configJson is not pure JSON - it contains data after the object ends, but this does not break parsing.
-        return JsonBrowser.parse(configJson);
-      }
-
-      log.debug("Did not find player config in track {} embed page HTML: {}", videoId, html);
-    }
-
-    throw new FriendlyException("Track information is unavailable.", SUSPICIOUS,
-        new IllegalStateException("Expected player config is not present in embed page."));
-  }
-
-  protected JsonBrowser loadTrackArgsFromVideoInfoPage(HttpInterface httpInterface, String videoId, String sts) throws IOException {
-    String videoApiUrl = "https://youtube.googleapis.com/v/" + videoId;
-    String encodedApiUrl = URLEncoder.encode(videoApiUrl, UTF_8.name());
-    String url = "https://www.youtube.com/get_video_info?video_id=" + videoId + "&eurl=" + encodedApiUrl +
-        "&hl=en_GB&html5=1&c=ANDROID&cver=16.24";
-
-    if (sts != null) {
-      url += "&sts=" + sts;
-    }
-
-    JsonBrowser values = JsonBrowser.newMap();
-
-    try (CloseableHttpResponse response = httpInterface.execute(new HttpGet(url))) {
+    try (CloseableHttpResponse response = httpInterface.execute(post)) {
       HttpClientTools.assertSuccessWithContent(response, "video info response");
 
-      for (NameValuePair pair : URLEncodedUtils.parse(response.getEntity())) {
-        values.put(pair.getName(), pair.getValue());
+      String json = EntityUtils.toString(response.getEntity(), UTF_8);
+      if (json != null) {
+        return JsonBrowser.parse(json);
       }
+
+      log.error("Did not receive response from Innertube request on track {} response: {}", videoId, response);
     }
 
-    return values;
+    throw new FriendlyException("Track requires age verification.", SUSPICIOUS,
+            new IllegalStateException("Expected response is not present."));
   }
 
   protected JsonBrowser loadTrackInfoWithContentVerifyRequest(HttpInterface httpInterface, String videoId) throws IOException {

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetailsLoader.java
@@ -27,7 +27,7 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
   private static final String AGE_VERIFY_REQUEST_URL = "https://www.youtube.com/youtubei/v1/verify_age?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
   private static final String AGE_VERIFY_REQUEST_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"WEB\",\"clientVersion\":\"2.20210302.07.01\"}},\"nextEndpoint\":{\"urlEndpoint\":{\"url\":\"%s\"}},\"setControvercy\":true}";
   private static final String PLAYER_REQUEST_URL = "https://www.youtube.com/youtubei/v1/player?key=AIzaSyAO_FJ2SlqU8Q4STEHLGCilw_Y9_11qcW8";
-  private static final String PLAYER_REQUEST_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"ANDROID\",\"clientVersion\":\"16.24\",\"clientScreen\":\"EMBED\"}},\"racyCheckOk\":true,\"contentCheckOk\":true,\"videoId\":\"%s\"}";
+  private static final String PLAYER_REQUEST_PAYLOAD = "{\"context\":{\"client\":{\"clientName\":\"ANDROID\",\"clientVersion\":\"16.24\",\"clientScreen\":\"EMBED\"},\"thirdParty\":{\"embedUrl\":\"https://www.youtube.com\"}},\"racyCheckOk\":true,\"contentCheckOk\":true,\"videoId\":\"%s\"}";
 
   private volatile CachedPlayerScript cachedPlayerScript = null;
 
@@ -187,12 +187,12 @@ public class DefaultYoutubeTrackDetailsLoader implements YoutubeTrackDetailsLoad
     try (CloseableHttpResponse response = httpInterface.execute(post)) {
       HttpClientTools.assertSuccessWithContent(response, "video info response");
 
-      String json = EntityUtils.toString(response.getEntity(), UTF_8);
+      JsonBrowser json = JsonBrowser.parse(EntityUtils.toString(response.getEntity(), UTF_8));
       if (json != null) {
-        return JsonBrowser.parse(json);
+        return json;
       }
 
-      log.error("Did not receive response from Innertube request on track {} response: {}", videoId, response);
+      log.error("Did not receive expected response from Innertube request on track {} response: {}", videoId, response);
     }
 
     throw new FriendlyException("Track requires age verification.", SUSPICIOUS,

--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackJsonData.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackJsonData.java
@@ -38,6 +38,10 @@ public class YoutubeTrackJsonData {
           if (playerResponse.isNull()) {
             playerResponse = child.get("playerResponse");
           }
+        } else {
+          if (playerResponse.isNull()) {
+            playerResponse = result;
+          }
         }
       }
 
@@ -51,18 +55,6 @@ public class YoutubeTrackJsonData {
     }
 
     throw throwWithDebugInfo(log, null, "Neither player nor playerResponse in result", "json", result.format());
-  }
-
-  public static YoutubeTrackJsonData fromEmbedParts(JsonBrowser embedInfo, JsonBrowser videoInfo) {
-    String playerScriptUrl = embedInfo.get("assets").get("js").text();
-    String playerResponseText = videoInfo.get("player_response").text();
-
-    if (playerResponseText == null) {
-      String embeddedPlayerResponseText = embedInfo.get("args").get("embedded_player_response").text();
-      return new YoutubeTrackJsonData(parsePlayerResponse(embeddedPlayerResponseText), videoInfo, playerScriptUrl);
-    }
-
-    return new YoutubeTrackJsonData(parsePlayerResponse(playerResponseText), videoInfo, playerScriptUrl);
   }
 
   private static YoutubeTrackJsonData fromPolymerPlayerInfo(JsonBrowser playerInfo, JsonBrowser playerResponse) {


### PR DESCRIPTION
It's better to completely switch to InnerTube API (this will fix 403 error completely), also will be good create something like `YoutubeConstants` for containing all payloads and urls for requests to API, if sedmelluq okay with that I will do it

Also want to mention that this PR will not allow play all age restricted videos, some of them require actually auth in YT, this can be emulated by providing auth cookie from YT account