### PR TITLE
Fixed bug with youtube track details parsing

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackJsonData.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/YoutubeTrackJsonData.java
@@ -29,6 +29,11 @@ public class YoutubeTrackJsonData {
       JsonBrowser playerInfo = NULL_BROWSER;
       JsonBrowser playerResponse = NULL_BROWSER;
 
+      if (result.isMap()) {
+          playerInfo = result.get("player");
+          playerResponse = result.get("playerResponse");
+      }
+      
       for (JsonBrowser child : result.values()) {
         if (child.isMap()) {
           if (playerInfo.isNull()) {


### PR DESCRIPTION
This must have been changed very recently as the JSON format returned by Youtube has changed slightly in structure. Added code to optionally pull "player" and "playerResponse" elements from the results map at the top level first rather than as child values.