### PR TITLE
Youtube premieres identified by isLive videoDetails json key

### DIFF
--- a/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
+++ b/main/src/main/java/com/sedmelluq/discord/lavaplayer/source/youtube/DefaultYoutubeTrackDetails.java
@@ -94,6 +94,7 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
 
     TemporalInfo temporalInfo = TemporalInfo.fromRawData(
         videoDetails.get("isLiveContent").asBoolean(false),
+        videoDetails.get("isLive").asBoolean(false),
         videoDetails.get("lengthSeconds")
     );
 
@@ -109,6 +110,7 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
 
     TemporalInfo temporalInfo = TemporalInfo.fromRawData(
         "1".equals(args.get("live_playback").text()),
+        false,
         args.get("length_seconds")
     );
 
@@ -129,11 +131,11 @@ public class DefaultYoutubeTrackDetails implements YoutubeTrackDetails {
       this.durationMillis = durationMillis;
     }
 
-    public static TemporalInfo fromRawData(boolean wasLiveStream, JsonBrowser durationSecondsField) {
+    public static TemporalInfo fromRawData(boolean wasLiveStream, boolean isSpecifiedLive, JsonBrowser durationSecondsField) {
       long durationValue = durationSecondsField.asLong(0L);
       // VODs are not really live streams, even though that field in JSON claims they are. If it is actually live, then
       // duration is also missing or 0.
-      boolean isActiveStream = wasLiveStream && durationValue == 0;
+      boolean isActiveStream = isSpecifiedLive || (wasLiveStream && durationValue == 0);
 
       return new TemporalInfo(
           isActiveStream,


### PR DESCRIPTION
This PR fixes lavaplayer to play YouTube Premiere videos correctly - currently the video begins playing (at the active premiere timestamp) then stops after a few seconds, instead of playing to the end.

YouTube Premieres are basically "pre-recorded livestreams" -- channels upload a video, then start an automated livestream that plays it back with all the usual livestream features (chat, etc.). Lavaplayer should treat these as livestreams in order to play them correctly, but Premieres show the pre-recorded video length which confuses lavaplayer into thinking it's a normal video. 

A (possibly new?) videoDetails json key `isLive` is available to tell if a video is a currently-streaming livestream or Premiere. This PR updates lavaplayer to use that field to identify content that should be streamed.

Further bug details:
- An easy use-case to check is "lofi" videos -- many lofi channels use both livestreams and premieres to provide their long-running content.
- I have tested what youtube returns in the following cases:
  - A non-livestream, non-premiere video's json will have `"isLiveContent": false, "lengthSeconds": <length>`
  - An active livestream video's json will have `"isLiveContent": true, "isLive": true, "lengthSeconds": 0`
  - An ended/past livestream video's json will have `"isLiveContent": true, "lengthSeconds": <length>`
  - An active premiere video's json will have `"isLiveContent": false, "isLive": true, "lengthSeconds": <length>`
  - An ended/past premiere video's json will have `"isLiveContent": false, "lengthSeconds": <length>`

